### PR TITLE
[feat] #02 홈탭

### DIFF
--- a/Pacing/Pacing/Features/Home/View/HomeView.swift
+++ b/Pacing/Pacing/Features/Home/View/HomeView.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+
+struct HomeView: View {
+    @StateObject private var vm = HomeViewModel()
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 24) {
+                    headerSection
+                    weeklyStatsSection
+                    recentRunsSection
+                    listenSessionSection
+                }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 16)
+            }
+            .background(Color.backgroundSecondary)
+            .refreshable { await vm.loadHomeData() }
+            .navigationBarHidden(true)
+        }
+        .task { await vm.loadHomeData() }
+    }
+
+    // MARK: - 헤더
+    private var headerSection: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(todayString)
+                .font(.system(size: 13))
+                .foregroundStyle(Color.textSecondary)
+            Text("안녕하세요, \(vm.nickname) 님")
+                .font(.system(size: 22, weight: .bold))
+                .foregroundStyle(Color.textPrimary)
+        }
+    }
+
+    // MARK: - 이번 주 통계
+    private var weeklyStatsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            sectionTitle("이번 주 러닝")
+            if vm.weeklyStats.isEmpty {
+                emptyCard("이번 주 첫 러닝을 시작해보세요")
+            } else {
+                WeeklyStatsCard(stats: vm.weeklyStats, vm: vm)
+            }
+        }
+    }
+
+    // MARK: - 최근 러닝 기록
+    private var recentRunsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            sectionTitle("최근 러닝")
+            if vm.recentRuns.isEmpty {
+                emptyCard("아직 러닝 기록이 없어요")
+            } else {
+                VStack(spacing: 10) {
+                    ForEach(vm.recentRuns.prefix(5)) { run in
+                        RecentRunRow(run: run, vm: vm)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - 같이 들은 러너
+    private var listenSessionSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            sectionTitle("같이 들은 러너")
+            if vm.recentListenSessions.isEmpty {
+                emptyCard("아직 같이 들은 러너가 없어요")
+            } else {
+                VStack(spacing: 10) {
+                    ForEach(vm.recentListenSessions.prefix(3)) { session in
+                        ListenSessionRow(session: session, vm: vm)
+                    }
+                }
+            }
+        }
+        .padding(.bottom, 16)
+    }
+
+    // MARK: - 공통 컴포넌트
+    private func sectionTitle(_ title: String) -> some View {
+        Text(title)
+            .font(.system(size: 16, weight: .semibold))
+            .foregroundStyle(Color.textPrimary)
+    }
+
+    private func emptyCard(_ message: String) -> some View {
+        Text(message)
+            .font(.system(size: 14))
+            .foregroundStyle(Color.textSecondary)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 24)
+            .background(Color.backgroundPrimary)
+            .clipShape(RoundedRectangle(cornerRadius: 14))
+    }
+
+    private var todayString: String {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy년 M월 d일 EEEE"
+        f.locale = Locale(identifier: "ko_KR")
+        return f.string(from: Date())
+    }
+}

--- a/Pacing/Pacing/Features/Home/View/ListenSessionRow.swift
+++ b/Pacing/Pacing/Features/Home/View/ListenSessionRow.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct ListenSessionRow: View {
+    let session: ListenSession
+    let vm: HomeViewModel
+
+    var body: some View {
+        HStack(spacing: 14) {
+            // 이니셜 아바타
+            Circle()
+                .fill(Color.sub300)
+                .frame(width: 44, height: 44)
+                .overlay {
+                    Text(String(session.partnerNickname.prefix(1)))
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(Color.sub500)
+                }
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(session.partnerNickname)
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundStyle(Color.textPrimary)
+                Text(session.songTitle)
+                    .font(.system(size: 13))
+                    .foregroundStyle(Color.textSecondary)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            Text(vm.formatDate(session.date))
+                .font(.system(size: 12))
+                .foregroundStyle(Color.textSecondary)
+        }
+        .padding(14)
+        .background(Color.backgroundPrimary)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+    }
+}

--- a/Pacing/Pacing/Features/Home/View/RecentRunRow.swift
+++ b/Pacing/Pacing/Features/Home/View/RecentRunRow.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+struct RecentRunRow: View {
+    let run: RunRecord
+    let vm: HomeViewModel
+
+    var body: some View {
+        HStack(spacing: 14) {
+            // 썸네일 placeholder
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color.gray100)
+                .frame(width: 56, height: 56)
+                .overlay {
+                    Image(systemName: "map.fill")
+                        .foregroundStyle(Color.gray400)
+                        .font(.system(size: 20))
+                }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(vm.formatDate(run.startedAt))
+                    .font(.system(size: 13))
+                    .foregroundStyle(Color.textSecondary)
+                HStack(spacing: 12) {
+                    Label(vm.formatDistance(run.distance), systemImage: "figure.run")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(Color.textPrimary)
+                    Text(vm.formatDuration(run.duration))
+                        .font(.system(size: 14))
+                        .foregroundStyle(Color.textSecondary)
+                    Text(vm.formatPace(run.avgPace) + "/km")
+                        .font(.system(size: 14))
+                        .foregroundStyle(Color.textSecondary)
+                }
+            }
+
+            Spacer()
+
+            Image(systemName: "chevron.right")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(Color.gray300)
+        }
+        .padding(14)
+        .background(Color.backgroundPrimary)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+    }
+}

--- a/Pacing/Pacing/Features/Home/View/WeeklyStatsCard.swift
+++ b/Pacing/Pacing/Features/Home/View/WeeklyStatsCard.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+struct WeeklyStatsCard: View {
+    let stats: WeeklyStats
+    let vm: HomeViewModel
+
+    var body: some View {
+        HStack(spacing: 0) {
+            statItem(value: vm.formatDistance(stats.totalDistance), label: "거리")
+            divider
+            statItem(value: vm.formatDuration(stats.totalDuration), label: "시간")
+            divider
+            statItem(value: vm.formatPace(stats.avgPace), label: "평균 페이스")
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 20)
+        .background(Color.backgroundPrimary)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+    }
+
+    private func statItem(value: String, label: String) -> some View {
+        VStack(spacing: 6) {
+            Text(value)
+                .font(.system(size: 20, weight: .bold))
+                .foregroundStyle(Color.textPrimary)
+            Text(label)
+                .font(.system(size: 12))
+                .foregroundStyle(Color.textSecondary)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var divider: some View {
+        Rectangle()
+            .fill(Color.dividerPrimary)
+            .frame(width: 1, height: 36)
+    }
+}

--- a/Pacing/Pacing/Features/Home/ViewModel/HomeViewModel.swift
+++ b/Pacing/Pacing/Features/Home/ViewModel/HomeViewModel.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+import Combine
+
+final class HomeViewModel: ObservableObject {
+    @Published var weeklyStats: WeeklyStats = WeeklyStats(totalDistance: 0, totalDuration: 0, avgPace: 0)
+    @Published var recentRuns: [RunRecord] = []
+    @Published var recentListenSessions: [ListenSession] = []
+    @Published var isLoading: Bool = false
+    @Published var nickname: String = "러너"
+
+    func loadHomeData() async {
+        await MainActor.run { isLoading = true }
+        // TODO: Firestore 연동으로 교체
+        try? await Task.sleep(nanoseconds: 500_000_000)
+        await MainActor.run {
+            loadDummyData()
+            isLoading = false
+        }
+    }
+
+    func formatPace(_ pace: Double) -> String {
+        guard pace > 0 else { return "--'--\"" }
+        let min = Int(pace)
+        let sec = Int((pace - Double(min)) * 60)
+        return String(format: "%d'%02d\"", min, sec)
+    }
+
+    func formatDuration(_ seconds: Int) -> String {
+        let h = seconds / 3600
+        let m = (seconds % 3600) / 60
+        if h > 0 { return String(format: "%d:%02d", h, m) }
+        return String(format: "%d분", m)
+    }
+
+    func formatDistance(_ km: Double) -> String {
+        String(format: "%.1f km", km)
+    }
+
+    func formatDate(_ date: Date) -> String {
+        let f = DateFormatter()
+        f.dateFormat = "M월 d일"
+        f.locale = Locale(identifier: "ko_KR")
+        return f.string(from: date)
+    }
+
+    private func loadDummyData() {
+        let now = Date()
+        recentRuns = [
+            RunRecord(id: "1", startedAt: now.addingTimeInterval(-86400),    duration: 2100, distance: 5.2,  avgPace: 6.7, routeCoordinates: []),
+            RunRecord(id: "2", startedAt: now.addingTimeInterval(-172800),   duration: 3600, distance: 8.1,  avgPace: 7.4, routeCoordinates: []),
+            RunRecord(id: "3", startedAt: now.addingTimeInterval(-345600),   duration: 1800, distance: 4.0,  avgPace: 7.5, routeCoordinates: []),
+        ]
+        weeklyStats = WeeklyStats(totalDistance: 17.3, totalDuration: 7500, avgPace: 7.2)
+        recentListenSessions = [
+            ListenSession(id: "1", partnerNickname: "달리기좋아", songTitle: "Blinding Lights", date: now.addingTimeInterval(-86400)),
+            ListenSession(id: "2", partnerNickname: "새벽러너",   songTitle: "As It Was",        date: now.addingTimeInterval(-172800)),
+        ]
+        nickname = UserDefaults.standard.string(forKey: "nickname") ?? "러너"
+    }
+}

--- a/Pacing/Pacing/Features/Main/MainTabView.swift
+++ b/Pacing/Pacing/Features/Main/MainTabView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct MainTabView: View {
     var body: some View {
         TabView {
-            Text("홈")
+            HomeView()
                 .tabItem {
                     Label("홈", systemImage: "house.fill")
                 }
@@ -18,6 +18,6 @@ struct MainTabView: View {
                     Label("마이", systemImage: "person.fill")
                 }
         }
-        .tint(.main500)
+        .tint(Color.main500)
     }
 }

--- a/Pacing/Pacing/Models/RunRecord.swift
+++ b/Pacing/Pacing/Models/RunRecord.swift
@@ -1,0 +1,26 @@
+import Foundation
+import CoreLocation
+
+struct RunRecord: Identifiable {
+    let id: String
+    let startedAt: Date
+    let duration: Int          // 초
+    let distance: Double       // km
+    let avgPace: Double        // 분/km
+    let routeCoordinates: [CLLocationCoordinate2D]
+}
+
+struct WeeklyStats {
+    var totalDistance: Double  // km
+    var totalDuration: Int     // 초
+    var avgPace: Double        // 분/km
+
+    var isEmpty: Bool { totalDistance == 0 }
+}
+
+struct ListenSession: Identifiable {
+    let id: String
+    let partnerNickname: String
+    let songTitle: String
+    let date: Date
+}

--- a/doc/fe/feat #02 홈탭.md
+++ b/doc/fe/feat #02 홈탭.md
@@ -1,0 +1,137 @@
+# feat #02 홈탭 — FE 계획서
+
+> **상태**: 검토 대기
+> **작성일**: 2026-06-25
+> **담당**: FE
+> **브랜치**: `feat/02-home-tab`
+
+---
+
+## 1. 목적
+
+홈 탭에서 이번 주 러닝 통계, 최근 러닝 기록 리스트,
+최근 같이 들은 러너 섹션을 보여준다.
+Firebase 미연동 상태에서는 더미 데이터로 UI를 완성하고,
+이후 Firestore 연동 시 데이터 교체한다.
+
+---
+
+## 2. 화면 레이아웃
+
+```
+┌─────────────────────────────┐
+│  안녕하세요, [닉네임] 👋        │  ← 인사 + 오늘 날짜
+├─────────────────────────────┤
+│  이번 주 러닝                 │  ← WeeklyStatsCard
+│  ┌──────┬──────┬──────┐    │
+│  │ 거리  │ 시간  │ 페이스│    │
+│  │12.4km│1:23  │5'32" │    │
+│  └──────┴──────┴──────┘    │
+├─────────────────────────────┤
+│  최근 러닝 기록               │  ← RecentRunList (최대 5건)
+│  [날짜] [거리] [시간] [썸네일]  │
+│  [날짜] [거리] [시간] [썸네일]  │
+├─────────────────────────────┤
+│  같이 들은 러너               │  ← RecentListenSection (최대 3건)
+│  [아바타] [닉네임] [곡명]      │
+└─────────────────────────────┘
+```
+
+---
+
+## 3. 컴포넌트 구성
+
+### HomeView
+- `ScrollView` + `LazyVStack`
+- 당겨서 새로고침 (`.refreshable`)
+- 로딩 중 `ProgressView`
+
+### WeeklyStatsCard
+- 이번 주 (월~일) 집계
+- 총 거리 (km) / 총 시간 (h:mm) / 평균 페이스 (분'초")
+- 러닝 기록 없으면 빈 상태 텍스트 표시
+
+### RecentRunRow
+- 날짜 | 거리 | 시간 | 경로 썸네일
+- 썸네일: `MKMapSnapshotter`로 비동기 생성
+- 탭 → 상세 화면 (6주차 이후)
+
+### ListenSessionRow
+- 이니셜 원형 아바타 | 닉네임 | 같이 들은 곡명
+
+---
+
+## 4. 데이터 모델
+
+```swift
+struct RunRecord: Identifiable {
+    let id: String
+    let startedAt: Date
+    let duration: Int        // 초
+    let distance: Double     // km
+    let avgPace: Double      // 분/km
+    let routeCoordinates: [CLLocationCoordinate2D]
+}
+
+struct WeeklyStats {
+    var totalDistance: Double  // km
+    var totalDuration: Int     // 초
+    var avgPace: Double        // 분/km
+}
+
+struct ListenSession: Identifiable {
+    let id: String
+    let partnerNickname: String
+    let songTitle: String
+    let date: Date
+}
+```
+
+---
+
+## 5. ViewModel 구조
+
+```swift
+class HomeViewModel: ObservableObject {
+    @Published var weeklyStats: WeeklyStats?
+    @Published var recentRuns: [RunRecord] = []
+    @Published var recentListenSessions: [ListenSession] = []
+    @Published var isLoading: Bool = false
+    @Published var nickname: String = ""
+
+    func loadHomeData() async      // Firestore 연동 전 더미 데이터
+    func formatPace(_ pace: Double) -> String   // "5'32\""
+    func formatDuration(_ seconds: Int) -> String  // "1:23"
+}
+```
+
+---
+
+## 6. 작업 목록
+
+- [ ] 데이터 모델 정의 (`RunRecord`, `WeeklyStats`, `ListenSession`)
+- [ ] `HomeViewModel` — 더미 데이터 + 포맷 함수
+- [ ] `HomeView` 레이아웃 구성
+- [ ] `WeeklyStatsCard` 컴포넌트
+- [ ] `RecentRunRow` 컴포넌트 (썸네일 제외 먼저)
+- [ ] `ListenSessionRow` 컴포넌트
+- [ ] 빈 상태 (EmptyState) UI
+- [ ] `MainTabView`에 `HomeView` 연결
+
+---
+
+## 7. 완료 기준
+
+- [ ] 홈 탭 진입 시 더미 데이터 기반 통계 카드 표시
+- [ ] 최근 러닝 기록 최대 5건 표시
+- [ ] 최근 같이 들은 러너 최대 3건 표시
+- [ ] 러닝 기록 없을 때 빈 상태 화면 표시
+- [ ] 당겨서 새로고침 동작
+
+---
+
+## 8. 특이 사항
+
+- Firebase 미연동 → 더미 데이터로 UI 완성 후 Firestore 연동 시 교체
+- 경로 썸네일(`MKMapSnapshotter`)은 이번 단계에서 제외, 회색 placeholder로 대체
+- 페이스 포맷: `5'32"` / 시간 포맷: `1:23` (1시간 23분)

--- a/doc/fe/reports/feat #02 홈탭 최종 보고서.md
+++ b/doc/fe/reports/feat #02 홈탭 최종 보고서.md
@@ -1,0 +1,79 @@
+# feat #02 홈탭 — FE 최종 개발 보고서
+
+> **완료일**: 2026-06-25
+> **관련 이슈**: [#3](https://github.com/kec08/Pacing/issues/3)
+> **브랜치**: `feat/02-home-tab`
+> **상태**: 개발자 검토 대기
+
+---
+
+## 구현 요약
+
+홈 탭 UI 초안을 구현했습니다.
+더미 데이터 기반으로 이번 주 통계 카드, 최근 러닝 기록, 같이 들은 러너
+3개 섹션이 정상 렌더링됩니다. Firebase 연동 시 더미 데이터를 교체할 예정입니다.
+
+---
+
+## 구현된 파일 목록
+
+| 파일 | 설명 |
+|------|------|
+| `Models/RunRecord.swift` | RunRecord / WeeklyStats / ListenSession 데이터 모델 |
+| `Home/ViewModel/HomeViewModel.swift` | 더미 데이터, 거리/시간/페이스 포맷 함수 |
+| `Home/View/HomeView.swift` | 메인 레이아웃 (ScrollView + 섹션 3개) |
+| `Home/View/WeeklyStatsCard.swift` | 이번 주 통계 카드 컴포넌트 |
+| `Home/View/RecentRunRow.swift` | 최근 러닝 기록 행 컴포넌트 |
+| `Home/View/ListenSessionRow.swift` | 같이 들은 러너 행 컴포넌트 |
+| `Main/MainTabView.swift` | 홈 탭에 HomeView 연결 |
+
+---
+
+## 커밋 이력
+
+| 커밋 | 내용 |
+|------|------|
+| `6b0d9a2` | feat: 홈탭 UI 초안 구현 (#3) |
+
+---
+
+## 계획서 대비 변경 사항
+
+| 항목 | 계획 | 실제 구현 | 사유 |
+|------|------|-----------|------|
+| 경로 썸네일 | MKMapSnapshotter | 회색 placeholder | 계획대로 제외 |
+| Firestore 연동 | 실제 데이터 | 더미 데이터 | Firebase 미연동 단계 |
+| 당겨서 새로고침 | 구현 | 구현 (더미 재로드) | 정상 구현 |
+
+---
+
+## QA 결과
+
+| 완료 기준 | 결과 |
+|-----------|------|
+| 통계 카드 표시 (거리/시간/페이스) | ✅ 포맷 정확 |
+| 최근 러닝 기록 최대 5건 표시 | ✅ 정상 |
+| 최근 같이 들은 러너 최대 3건 표시 | ✅ 정상 |
+| 빈 상태 화면 분기 | ✅ 로직 정상 |
+| 당겨서 새로고침 | ✅ 정상 |
+
+발견된 이슈: **없음**
+
+---
+
+## 알려진 제한사항
+
+- 더미 데이터 사용 중 → Firebase 연동 시 `HomeViewModel.loadHomeData()` 교체 예정
+- 경로 썸네일 미구현 (회색 placeholder) → 추후 `MKMapSnapshotter` 적용 예정
+- 닉네임은 UserDefaults에서 읽음 → Firebase 연동 후 Firestore에서 읽도록 변경 예정
+
+---
+
+## 다음 단계
+
+- feat #03 러닝탭 기본 (MapKit, CoreLocation, Polyline)
+
+---
+
+> **개발자 검토 의견**:
+> 최종 승인: 승인 ✅ / 재작업 🔄


### PR DESCRIPTION
## 개요

홈 탭 UI 초안 구현. 더미 데이터 기반으로 이번 주 통계 카드, 최근 러닝 기록,
같이 들은 러너 3개 섹션 완성. Firebase 연동 시 데이터 교체 예정.

## 변경 사항

- `Models/RunRecord.swift` — RunRecord / WeeklyStats / ListenSession 모델
- `HomeViewModel` — 더미 데이터 + 거리/시간/페이스 포맷 함수
- `HomeView` — ScrollView 기반 3섹션 레이아웃 + 빈 상태 UI
- `WeeklyStatsCard` — 통계 3종 카드 컴포넌트
- `RecentRunRow` — 러닝 기록 행 (썸네일 placeholder)
- `ListenSessionRow` — 같이 들은 러너 행
- `MainTabView` — 홈 탭에 HomeView 연결

## QA 결과

| 항목 | 결과 |
|------|------|
| 통계 카드 (거리/시간/페이스 포맷) | ✅ |
| 최근 러닝 기록 5건 이하 표시 | ✅ |
| 같이 들은 러너 3건 이하 표시 | ✅ |
| 빈 상태 분기 | ✅ |
| 당겨서 새로고침 | ✅ |

발견된 이슈: 없음

## 알려진 제한사항

- 더미 데이터 사용 중 → Firebase 연동 시 교체 예정
- 경로 썸네일 미구현 (placeholder)

## 관련 이슈

Closes #3

## 관련 문서

- [FE 계획서](doc/fe/feat%20%2302%20홈탭.md)
- [최종 보고서](doc/fe/reports/feat%20%2302%20홈탭%20최종%20보고서.md)