### PR TITLE
feat: Apple Music 플레이리스트 연동 및 음악 시트 UI 개선 (#06)

### DIFF
--- a/Pacing/Pacing/Features/Running/View/RunningView.swift
+++ b/Pacing/Pacing/Features/Running/View/RunningView.swift
@@ -112,13 +112,13 @@ struct RunningView: View {
             HStack(spacing: 10) {
                 if musicVM.isLoading {
                     ForEach(0..<5, id: \.self) { _ in musicCardSkeleton }
-                } else if musicVM.recentSongs.isEmpty {
+                } else if musicVM.playlists.isEmpty {
                     ForEach(dummyMusicCards, id: \.title) { card in
                         dummyMusicCard(title: card.title, artist: card.artist)
                     }
                 } else {
-                    ForEach(musicVM.recentSongs, id: \.id) { song in
-                        musicCardItem(song: song)
+                    ForEach(musicVM.playlists, id: \.id) { playlist in
+                        playlistCardItem(playlist: playlist)
                     }
                 }
             }
@@ -126,31 +126,33 @@ struct RunningView: View {
         }
     }
 
-    private func musicCardItem(song: Song) -> some View {
-        Button { showMusicSheet = true } label: {
+    private func playlistCardItem(playlist: Playlist) -> some View {
+        Button {
+            Task { await musicVM.play(playlist: playlist) }
+            showMusicSheet = true
+        } label: {
             HStack(spacing: 10) {
                 ZStack {
                     RoundedRectangle(cornerRadius: 8)
                         .fill(Color(.systemGray5))
                         .frame(width: 44, height: 44)
-                    if let artwork = song.artwork {
+                    if let artwork = playlist.artwork {
                         ArtworkImage(artwork, width: 44, height: 44)
                             .clipShape(RoundedRectangle(cornerRadius: 8))
                     } else {
-                        Image(systemName: "music.note")
+                        Image(systemName: "music.note.list")
                             .font(.system(size: 16))
                             .foregroundStyle(Color.main500)
                     }
                 }
                 VStack(alignment: .leading, spacing: 3) {
-                    Text(song.title)
+                    Text(playlist.name)
                         .font(.system(size: 12, weight: .semibold))
                         .foregroundStyle(Color.textPrimary)
                         .lineLimit(1)
-                    Text(song.artistName)
+                    Text("플레이리스트")
                         .font(.system(size: 11))
                         .foregroundStyle(Color.textSecondary)
-                        .lineLimit(1)
                 }
                 .frame(width: 100, alignment: .leading)
             }
@@ -467,46 +469,163 @@ struct RunningView: View {
 
     private var musicSheet: some View {
         NavigationStack {
-            VStack(spacing: 24) {
-                ZStack {
-                    RoundedRectangle(cornerRadius: 20)
-                        .fill(Color(.systemGray6))
-                        .frame(width: 200, height: 200)
-                    Image(systemName: "music.note")
-                        .font(.system(size: 60))
-                        .foregroundStyle(Color.main500)
-                }
-                VStack(spacing: 6) {
-                    if let song = musicVM.recentSongs.first {
-                        Text(song.title)
-                            .font(.system(size: 18, weight: .bold))
-                            .foregroundStyle(Color.textPrimary)
-                        Text(song.artistName)
-                            .font(.system(size: 15))
-                            .foregroundStyle(Color.textSecondary)
+            ZStack {
+                Color.clear
+
+                VStack(spacing: 0) {
+                    // 앨범 커버
+                    if musicVM.queueSongs.isEmpty {
+                        artworkPlaceholder
+                            .frame(width: 220, height: 220)
+                            .shadow(color: .black.opacity(0.25), radius: 16, y: 8)
+                            .padding(.top, 36)
+                            .padding(.bottom, 28)
                     } else {
-                        Text("Apple Music 라이브러리")
-                            .font(.system(size: 18, weight: .bold))
-                            .foregroundStyle(Color.textPrimary)
-                        Text("러닝에 맞는 음악을 선택하세요")
-                            .font(.system(size: 15))
-                            .foregroundStyle(Color.textSecondary)
+                        TabView(selection: Binding(
+                            get: { musicVM.currentSongIndex },
+                            set: { newIndex in
+                                musicVM.isGoingForward = newIndex > musicVM.currentSongIndex
+                                musicVM.currentSongIndex = newIndex
+                                Task { await musicVM.play(at: newIndex) }
+                            }
+                        )) {
+                            ForEach(musicVM.queueSongs.indices, id: \.self) { idx in
+                                let song = musicVM.queueSongs[idx]
+                                Group {
+                                    if let artwork = song.artwork {
+                                        ArtworkImage(artwork, width: 220, height: 220)
+                                            .clipShape(RoundedRectangle(cornerRadius: 20))
+                                    } else {
+                                        artworkPlaceholder
+                                    }
+                                }
+                                .frame(width: 220, height: 220)
+                                .shadow(color: .black.opacity(0.25), radius: 16, y: 8)
+                                .padding(.top, 12)
+                                .padding(.bottom, 28)
+                                .tag(idx)
+                            }
+                        }
+                        .tabViewStyle(.page(indexDisplayMode: .never))
+                        .frame(height: 276)
+                        .padding(.top, 24)
                     }
+
+                    // 곡 정보
+                    let insertEdge: Edge = musicVM.isGoingForward ? .trailing : .leading
+                    let removeEdge: Edge = musicVM.isGoingForward ? .leading : .trailing
+                    VStack(spacing: 6) {
+                        Text(musicVM.currentSong?.title ?? "플레이리스트를 선택하세요")
+                            .font(.system(size: 18, weight: .bold))
+                            .foregroundStyle(.primary)
+                            .lineLimit(1)
+                            .id(musicVM.currentSong?.id)
+                            .transition(.asymmetric(
+                                insertion: .move(edge: insertEdge).combined(with: .opacity),
+                                removal: .move(edge: removeEdge).combined(with: .opacity)
+                            ))
+                        Text(musicVM.currentSong?.artistName ?? "Apple Music")
+                            .font(.system(size: 15))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .id(musicVM.currentSong?.artistName)
+                            .transition(.asymmetric(
+                                insertion: .move(edge: insertEdge).combined(with: .opacity),
+                                removal: .move(edge: removeEdge).combined(with: .opacity)
+                            ))
+                    }
+                    .animation(.easeInOut(duration: 0.25), value: musicVM.currentSong?.id)
+                    .padding(.horizontal, 32)
+
+                    // 재생 컨트롤
+                    HStack(spacing: 48) {
+                        Button {
+                            Task { await musicVM.skipToPrevious() }
+                        } label: {
+                            Image(systemName: "backward.fill")
+                                .font(.system(size: 28))
+                                .foregroundStyle(.primary)
+                        }
+
+                        Button {
+                            Task { await musicVM.togglePlayPause() }
+                        } label: {
+                            Image(systemName: musicVM.isPlaying ? "pause.circle.fill" : "play.circle.fill")
+                                .font(.system(size: 64))
+                                .foregroundStyle(Color.main500)
+                        }
+
+                        Button {
+                            Task { await musicVM.skipToNext() }
+                        } label: {
+                            Image(systemName: "forward.fill")
+                                .font(.system(size: 28))
+                                .foregroundStyle(.primary)
+                        }
+                    }
+                    .padding(.top, 28)
+
+                    // 플레이리스트 섹션
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("내 플레이리스트")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal, 24)
+
+                        if musicVM.isLoading {
+                            ProgressView()
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 20)
+                        } else if musicVM.playlists.isEmpty {
+                            Text("플레이리스트가 없어요")
+                                .font(.system(size: 14))
+                                .foregroundStyle(.secondary)
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 20)
+                        } else {
+                            ScrollView(.horizontal, showsIndicators: false) {
+                                HStack(spacing: 16) {
+                                    ForEach(musicVM.playlists, id: \.id) { playlist in
+                                        Button {
+                                            Task { await musicVM.play(playlist: playlist) }
+                                        } label: {
+                                            VStack(spacing: 8) {
+                                                Group {
+                                                    if let artwork = playlist.artwork {
+                                                        ArtworkImage(artwork, width: 100, height: 100)
+                                                            .clipShape(RoundedRectangle(cornerRadius: 12))
+                                                    } else {
+                                                        ZStack {
+                                                            RoundedRectangle(cornerRadius: 12)
+                                                                .fill(.ultraThinMaterial)
+                                                                .frame(width: 100, height: 100)
+                                                            Image(systemName: "music.note.list")
+                                                                .font(.system(size: 28))
+                                                                .foregroundStyle(Color.main500)
+                                                        }
+                                                    }
+                                                }
+                                                .frame(width: 100, height: 100)
+                                                .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
+
+                                                Text(playlist.name)
+                                                    .font(.system(size: 12, weight: .medium))
+                                                    .foregroundStyle(.primary)
+                                                    .lineLimit(1)
+                                                    .frame(width: 100)
+                                            }
+                                        }
+                                    }
+                                }
+                                .padding(.horizontal, 24)
+                            }
+                        }
+                    }
+                    .padding(.top, 32)
+
+                    Spacer()
                 }
-                HStack(spacing: 40) {
-                    Image(systemName: "backward.fill")
-                        .font(.system(size: 28))
-                        .foregroundStyle(Color.textPrimary)
-                    Image(systemName: "play.circle.fill")
-                        .font(.system(size: 56))
-                        .foregroundStyle(Color.main500)
-                    Image(systemName: "forward.fill")
-                        .font(.system(size: 28))
-                        .foregroundStyle(Color.textPrimary)
-                }
-                Spacer()
             }
-            .padding(.top, 32)
             .navigationTitle("음악")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -515,6 +634,18 @@ struct RunningView: View {
                         .foregroundStyle(Color.main500)
                 }
             }
+        }
+        .presentationBackground(.ultraThinMaterial)
+    }
+
+    private var artworkPlaceholder: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 20)
+                .fill(.ultraThinMaterial)
+                .frame(width: 220, height: 220)
+            Image(systemName: "music.note")
+                .font(.system(size: 60))
+                .foregroundStyle(Color.main500)
         }
     }
 

--- a/Pacing/Pacing/Features/Running/ViewModel/RunningMusicViewModel.swift
+++ b/Pacing/Pacing/Features/Running/ViewModel/RunningMusicViewModel.swift
@@ -1,31 +1,164 @@
 import SwiftUI
-import Combine
 import MusicKit
+import MediaPlayer
+import Combine
 
 @MainActor
 final class RunningMusicViewModel: ObservableObject {
-    @Published var recentSongs: [Song] = []
     @Published var authStatus: MusicAuthorization.Status = .notDetermined
-    @Published var isLoading = false
+    @Published var playlists: [Playlist] = []
+    @Published var currentSong: Song? = nil
+    @Published var currentSongIndex: Int = 0
+    @Published var queueSongs: [Song] = []
+    @Published var isPlaying: Bool = false
+    @Published var isLoading: Bool = false
+    @Published var isGoingForward: Bool = true
 
+    private let player = MPMusicPlayerController.systemMusicPlayer
+    private var isManualSeeking: Bool = false
+    // 재생 중인 플레이리스트의 MPMediaItem 캐시
+    private var cachedMediaItems: [MPMediaItem] = []
+    private var notificationObservers: [NSObjectProtocol] = []
+
+    init() {
+        observePlaybackState()
+    }
+
+    deinit {
+        notificationObservers.forEach { NotificationCenter.default.removeObserver($0) }
+        player.endGeneratingPlaybackNotifications()
+    }
+
+    // MARK: - 권한 요청
     func requestAuthorization() async {
         authStatus = await MusicAuthorization.request()
         if authStatus == .authorized {
-            await fetchRecentSongs()
+            await fetchPlaylists()
+            syncCurrentState()
         }
     }
 
-    func fetchRecentSongs() async {
+    // MARK: - 플레이리스트 fetch
+    func fetchPlaylists() async {
         guard authStatus == .authorized else { return }
         isLoading = true
         do {
-            var request = MusicRecentlyPlayedRequest<Song>()
-            request.limit = 10
+            let request = MusicLibraryRequest<Playlist>()
             let response = try await request.response()
-            recentSongs = Array(response.items)
+            playlists = Array(response.items)
         } catch {
-            recentSongs = []
+            playlists = []
         }
         isLoading = false
+    }
+
+    // MARK: - 플레이리스트 재생
+    func play(playlist: Playlist) async {
+        // MusicKit에서 트랙 정보 로드
+        if let loaded = try? await playlist.with([.tracks]) {
+            queueSongs = loaded.tracks?.compactMap { track -> Song? in
+                if case .song(let song) = track { return song }
+                return nil
+            } ?? []
+        }
+
+        // MPMediaQuery로 플레이리스트 찾아서 재생
+        let query = MPMediaQuery.playlists()
+        let mediaPlaylists = query.collections as? [MPMediaPlaylist] ?? []
+
+        if let match = mediaPlaylists.first(where: { $0.name == playlist.name }) {
+            cachedMediaItems = match.items
+            let collection = MPMediaItemCollection(items: match.items)
+            player.setQueue(with: collection)
+            try? await player.prepareToPlay()
+            player.play()
+            currentSongIndex = 0
+            syncCurrentState()
+        }
+    }
+
+    // MARK: - 인덱스로 곡 직접 이동 (캐시된 아이템 활용)
+    func play(at index: Int) async {
+        guard index >= 0, index < cachedMediaItems.count else { return }
+        isManualSeeking = true
+        if index < queueSongs.count {
+            currentSong = queueSongs[index]
+        }
+        // UI 애니메이션이 완료된 후 재생 시작
+        try? await Task.sleep(nanoseconds: 150_000_000)
+        let targetItem = cachedMediaItems[index]
+        player.nowPlayingItem = targetItem
+        player.play()
+        isManualSeeking = false
+    }
+
+    // MARK: - 재생/일시정지
+    func togglePlayPause() async {
+        if isPlaying {
+            player.pause()
+        } else {
+            player.play()
+        }
+    }
+
+    // MARK: - 이전 곡
+    func skipToPrevious() async {
+        let newIndex = max(0, currentSongIndex - 1)
+        isGoingForward = false
+        currentSongIndex = newIndex
+        await play(at: newIndex)
+    }
+
+    // MARK: - 다음 곡
+    func skipToNext() async {
+        let newIndex = min(cachedMediaItems.count - 1, currentSongIndex + 1)
+        isGoingForward = true
+        currentSongIndex = newIndex
+        await play(at: newIndex)
+    }
+
+    // MARK: - 현재 상태 동기화
+    func syncCurrentState() {
+        isPlaying = player.playbackState == .playing
+        guard let item = player.nowPlayingItem else {
+            currentSong = nil
+            return
+        }
+        if let idx = cachedMediaItems.firstIndex(where: { $0.persistentID == item.persistentID }) {
+            if !isManualSeeking && idx != currentSongIndex {
+                isGoingForward = idx > currentSongIndex
+                currentSongIndex = idx
+            }
+            if idx < queueSongs.count {
+                currentSong = queueSongs[idx]
+            }
+        }
+    }
+
+    // MARK: - 재생 상태 구독
+    private func observePlaybackState() {
+        player.beginGeneratingPlaybackNotifications()
+
+        let stateObserver = NotificationCenter.default.addObserver(
+            forName: .MPMusicPlayerControllerPlaybackStateDidChange,
+            object: player,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.isPlaying = self?.player.playbackState == .playing
+            }
+        }
+
+        let itemObserver = NotificationCenter.default.addObserver(
+            forName: .MPMusicPlayerControllerNowPlayingItemDidChange,
+            object: player,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.syncCurrentState()
+            }
+        }
+
+        notificationObservers = [stateObserver, itemObserver]
     }
 }

--- a/doc/fe/feat #06 음악 연동.md
+++ b/doc/fe/feat #06 음악 연동.md
@@ -1,0 +1,80 @@
+# feat #06 음악 연동
+
+## 목표
+MusicKit을 통해 Apple Music 라이브러리 연동 — 앨범 커버 표시, 플레이리스트 목록, 곡 선택 및 실제 재생 제어
+
+---
+
+## 현재 상태 (feat/05 기준)
+- `RunningMusicViewModel`: `MusicRecentlyPlayedRequest`로 최근 재생 곡 fetch 시도
+- `musicSheet`: 앨범 커버 없이 더미 UI, 재생 버튼 동작 안 함
+- MusicKit entitlement 미적용 (프로비저닝 이슈로 보류됨)
+- 문제: `com.eunchan.Pacing` MusicKit 등록은 됐지만 entitlement 추가 시 빌드 실패
+
+---
+
+## 구현 목표
+
+### 1. MusicKit Entitlement 해결
+- `Pacing.entitlements`에 `com.apple.developer.musickit` 추가
+- Xcode Signing & Capabilities → MusicKit capability 추가
+- 프로비저닝 프로파일 갱신
+
+### 2. 음악 뷰 개선 (`musicSheet`)
+- **앨범 커버**: `song.artwork` → `ArtworkImage` 뷰로 실제 이미지 표시
+- **현재 재생 곡**: `ApplicationMusicPlayer.shared.queue.currentEntry` 반영
+- **재생/일시정지**: `ApplicationMusicPlayer.shared.play()` / `.pause()`
+- **이전/다음 곡**: `ApplicationMusicPlayer.shared.skipToPreviousEntry()` / `.skipToNextEntry()`
+- **재생 상태 연동**: `ApplicationMusicPlayer.shared.state.playbackStatus` 구독
+
+### 3. 플레이리스트 목록
+- `MusicLibraryRequest<Playlist>` 로 내 라이브러리 플레이리스트 fetch
+- 음악 시트 하단에 플레이리스트 목록 표시
+- 플레이리스트 탭 → 해당 플레이리스트 재생 시작
+
+### 4. 러닝 카드 (홈 화면) 연동
+- 현재 재생 중인 곡 앨범 커버 + 제목 표시
+
+---
+
+## 화면 구성
+
+### 음악 시트 (musicSheet)
+```
+┌─────────────────────────┐  ← .ultraThinMaterial 글래스 배경
+│         음악        완료  │     (뒤 지도가 블러 처리되어 비침)
+├─────────────────────────┤
+│                         │
+│   [앨범 커버 200x200]    │
+│                         │
+│      곡 제목             │
+│      아티스트명           │
+│                         │
+│   ◀◀    ▶/⏸    ▶▶     │
+│                         │
+│ ─── 내 플레이리스트 ───  │
+│ ← [커버] [커버] [커버] → │  ← 가로 스크롤
+│   러닝   밴드   인딘      │
+└─────────────────────────┘
+```
+
+- 시트 배경: `.presentationBackground(.ultraThinMaterial)` (iOS 16.4+)
+- 플레이리스트: 앨범 커버 이미지 + 이름 아래 표시, `ScrollView(.horizontal)` 가로 스크롤
+- 각 플레이리스트 카드 크기: 100×100 커버 + 이름 텍스트
+
+---
+
+## 기술 스택
+- `MusicKit` — Apple Music 라이브러리 접근
+- `ApplicationMusicPlayer` — 재생 제어
+- `MusicLibraryRequest<Playlist>` — 플레이리스트 목록
+- `ArtworkImage` — 앨범 커버 이미지 뷰
+
+---
+
+## 작업 순서
+1. MusicKit entitlement 추가 및 빌드 확인
+2. `RunningMusicViewModel` 개선 — 재생 상태, 플레이리스트 fetch
+3. `musicSheet` UI 개선 — 앨범 커버, 재생 컨트롤 동작
+4. 플레이리스트 목록 섹션 추가
+5. QA → 보고서 → 커밋/PR

--- a/doc/fe/reports/feat #06 음악 연동 최종 보고서.md
+++ b/doc/fe/reports/feat #06 음악 연동 최종 보고서.md
@@ -1,0 +1,77 @@
+# feat #06 음악 연동 최종 보고서
+
+## 개요
+
+| 항목 | 내용 |
+|------|------|
+| 브랜치 | `feat/06-music` |
+| 작업 기간 | 2026-06-25 ~ 2026-06-26 |
+| 담당 | kimeunchan |
+
+---
+
+## 구현 내용
+
+### 1. 음악 시트 UI 전면 개선
+- 시트 배경: `.presentationBackground(.ultraThinMaterial)` 글래스 효과 적용
+- 앨범 커버 영역: 220×220 크기, `RoundedRectangle(cornerRadius: 20)` 클리핑, 그림자 자연스럽게
+- 플레이리스트 미선택 상태도 동일한 레이아웃 (플레이스홀더 커버 + 텍스트) 로 통일
+
+### 2. 앨범 커버 캐러셀
+- `TabView` + `.page` 스타일로 가로 스와이프 선택
+- 스와이프 방향 감지 (`isGoingForward`) → 텍스트 슬라이드 방향 동기화
+- 이전/다음 버튼 탭 시 캐러셀도 함께 슬라이드
+
+### 3. 곡 정보 애니메이션
+- 제목/아티스트 텍스트에 `.asymmetric` transition 적용
+- 다음 곡: 오른쪽에서 진입 / 왼쪽으로 퇴장
+- 이전 곡: 왼쪽에서 진입 / 오른쪽으로 퇴장
+
+### 4. 플레이리스트 목록
+- `MusicLibraryRequest<Playlist>` 로 내 Apple Music 라이브러리 플레이리스트 fetch
+- 시트 하단 가로 스크롤 (`ScrollView(.horizontal)`)
+- 플레이리스트 탭 → 해당 플레이리스트 재생 시작
+
+### 5. 실제 재생 제어 (`RunningMusicViewModel`)
+- `MPMusicPlayerController.systemMusicPlayer` 기반 재생
+- 플레이리스트 선택 시 `MPMediaQuery`로 매칭 후 `MPMediaItemCollection` 큐 설정
+- `cachedMediaItems`에 현재 플레이리스트 아이템 캐시 → 곡 전환 시 즉시 `player.nowPlayingItem` 변경
+- 재생/일시정지/이전/다음 컨트롤
+- `MPMusicPlayerControllerNowPlayingItemDidChange` 알림 구독 → 상태 자동 동기화
+
+### 6. 곡 전환 끊김 최소화
+- `play(at:)` 호출 시 UI 업데이트 선행 후 150ms 후 재생 명령 → TabView 애니메이션과 충돌 방지
+- `isManualSeeking` 플래그로 노티피케이션이 인덱스를 덮어쓰는 현상 방지
+
+---
+
+## 미완 항목
+
+| 항목 | 사유 |
+|------|------|
+| MusicKit entitlement 정식 등록 | Developer Portal MusicKit 활성화 후 프로비저닝 프로파일 갱신 필요 — 배포 시 처리 |
+| `Client is not entitled to account store` 경고 | entitlement 미등록으로 인한 시스템 경고 — 재생 자체는 동작 |
+
+---
+
+## 주요 파일 변경 목록
+
+| 파일 | 변경 내용 |
+|------|-----------|
+| `Features/Running/ViewModel/RunningMusicViewModel.swift` | 전면 재작성 — MPMusicPlayerController 기반 재생, 캐시, 방향 추적 |
+| `Features/Running/View/RunningView.swift` | 음악 시트 UI 전면 개선 — 글래스 배경, 캐러셀, 방향별 애니메이션 |
+
+---
+
+## QA 결과
+
+| 항목 | 결과 |
+|------|------|
+| 플레이리스트 목록 표시 | ✅ Apple Music 라이브러리 플레이리스트 정상 표시 |
+| 앨범 커버 표시 | ✅ ArtworkImage로 실제 커버 이미지 표시 |
+| 플레이리스트 선택 → 재생 | ✅ 첫 번째 곡부터 재생 시작 |
+| 앨범 커버 스와이프 → 곡 이동 | ✅ 자연스러운 슬라이드 + 곡 전환 |
+| 이전/다음 버튼 → 곡 이동 | ✅ 캐러셀 슬라이드 + 곡 전환 |
+| 텍스트 전환 방향 동기화 | ✅ 이전/다음 방향에 맞게 슬라이드 |
+| 재생/일시정지 | ✅ 정상 동작 |
+| 글래스 배경 시트 | ✅ ultraThinMaterial 적용 |


### PR DESCRIPTION
## Summary
- `MPMusicPlayerController.systemMusicPlayer` 기반 실제 재생 구현
- 앨범 커버 캐러셀 (TabView page 스타일, 스와이프로 곡 선택)
- 글래스 배경 시트 (`.ultraThinMaterial`), 곡 전환 방향별 텍스트 슬라이드 애니메이션
- `cachedMediaItems` 캐시로 곡 전환 끊김 최소화, `isManualSeeking` 플래그로 노티피케이션 충돌 방지
- 플레이리스트 가로 스크롤 목록 (`MusicLibraryRequest<Playlist>`)

## Test plan
- [ ] 음악 시트 열기 → 플레이리스트 목록 표시 확인
- [ ] 플레이리스트 탭 → 앨범 커버 표시 + 재생 시작
- [ ] 앨범 커버 좌우 스와이프 → 자연스러운 슬라이드 + 곡 전환
- [ ] 이전/다음 버튼 → 캐러셀 슬라이드 + 곡 전환
- [ ] 재생/일시정지 버튼 동작
- [ ] 텍스트 전환 방향 (다음: 오른쪽 진입, 이전: 왼쪽 진입)

🤖 Generated with [Claude Code](https://claude.com/claude-code)