### PR TITLE
feat: 네이버 로그인 추가 및 게스트 로그인 제거 (#14)

### DIFF
--- a/Pacing/Pacing.xcodeproj/project.pbxproj
+++ b/Pacing/Pacing.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		BC5793752FF2672C006C925A /* KakaoSDKCommon in Frameworks */ = {isa = PBXBuildFile; productRef = BC5793742FF2672C006C925A /* KakaoSDKCommon */; };
 		BC5793772FF2672C006C925A /* KakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = BC5793762FF2672C006C925A /* KakaoSDKUser */; };
 		BC5793792FF26808006C925A /* FirebaseFunctions in Frameworks */ = {isa = PBXBuildFile; productRef = BC5793782FF26808006C925A /* FirebaseFunctions */; };
+		BC57937C2FF2CC58006C925A /* NaverThirdPartyLogin in Frameworks */ = {isa = PBXBuildFile; productRef = BC57937B2FF2CC58006C925A /* NaverThirdPartyLogin */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -85,6 +86,7 @@
 				BC5793772FF2672C006C925A /* KakaoSDKUser in Frameworks */,
 				BC5791DF2FED131F006C925A /* FirebaseAuth in Frameworks */,
 				BC5791E32FED131F006C925A /* FirebaseFirestore in Frameworks */,
+				BC57937C2FF2CC58006C925A /* NaverThirdPartyLogin in Frameworks */,
 				BC5793732FF2672C006C925A /* KakaoSDKAuth in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -155,6 +157,7 @@
 				BC5793742FF2672C006C925A /* KakaoSDKCommon */,
 				BC5793762FF2672C006C925A /* KakaoSDKUser */,
 				BC5793782FF26808006C925A /* FirebaseFunctions */,
+				BC57937B2FF2CC58006C925A /* NaverThirdPartyLogin */,
 			);
 			productName = Pacing;
 			productReference = BC57901A2FEC4AEF006C925A /* Pacing.app */;
@@ -242,6 +245,7 @@
 				BC5791DD2FED131F006C925A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				BC57936A2FF2415D006C925A /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */,
 				BC5793712FF2672C006C925A /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */,
+				BC57937A2FF2CC58006C925A /* XCRemoteSwiftPackageReference "naveridlogin-sdk-ios" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = BC57901B2FEC4AEF006C925A /* Products */;
@@ -674,6 +678,14 @@
 				minimumVersion = 2.28.0;
 			};
 		};
+		BC57937A2FF2CC58006C925A /* XCRemoteSwiftPackageReference "naveridlogin-sdk-ios" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/naver/naveridlogin-sdk-ios";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -720,6 +732,11 @@
 		BC5793782FF26808006C925A /* FirebaseFunctions */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = FirebaseFunctions;
+		};
+		BC57937B2FF2CC58006C925A /* NaverThirdPartyLogin */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BC57937A2FF2CC58006C925A /* XCRemoteSwiftPackageReference "naveridlogin-sdk-ios" */;
+			productName = NaverThirdPartyLogin;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Pacing/Pacing/Core/Auth/AuthViewModel.swift
+++ b/Pacing/Pacing/Core/Auth/AuthViewModel.swift
@@ -5,6 +5,7 @@ import FirebaseCore
 import FirebaseFunctions
 import AuthenticationServices
 import CryptoKit
+import NaverThirdPartyLogin
 #if canImport(GoogleSignIn)
 import GoogleSignIn
 #endif
@@ -16,7 +17,7 @@ import KakaoSDKUser
 
 @MainActor
 final class AuthViewModel: ObservableObject {
-    @Published var isLoading = false
+    @Published var isLoading = false  // LoginView에서 scenePhase 감지로 리셋 가능
     @Published var errorMessage: String?
 
     private var currentNonce: String?
@@ -153,6 +154,74 @@ final class AuthViewModel: ObservableObject {
         ["nickname", "height", "weight", "age", "profileImageBase64"].forEach { d.removeObject(forKey: $0) }
     }
 
+    // MARK: - 네이버 로그인 (ASWebAuthenticationSession + Firebase Hosting 리다이렉트)
+    nonisolated(unsafe) static var naverLoginCompletion: ((Result<String, Error>) -> Void)?
+    nonisolated(unsafe) private static var _naverSession: ASWebAuthenticationSession?
+    nonisolated(unsafe) private static var _naverContext: NaverPresentationContext?
+
+    func signInWithNaver(appState: AppState) async {
+        isLoading = true
+        defer { isLoading = false; appState.isAuthLoading = false }
+
+        let clientID = "hxrh7_6fG3iRc6tKxOuY"
+        let redirectURI = "https://pacing-a8639.web.app/naver-callback"
+        let state = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+
+        var comps = URLComponents(string: "https://nid.naver.com/oauth2.0/authorize")!
+        comps.queryItems = [
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "client_id",     value: clientID),
+            URLQueryItem(name: "redirect_uri",  value: redirectURI),
+            URLQueryItem(name: "state",         value: state),
+        ]
+        guard let authURL = comps.url else { return }
+
+        do {
+            let callbackURL: URL = try await withCheckedThrowingContinuation { continuation in
+                guard let scene = UIApplication.shared.connectedScenes
+                    .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene,
+                      let window = scene.windows.first(where: { $0.isKeyWindow })
+                else { continuation.resume(throwing: NSError(domain: "NaverLogin", code: -2)); return }
+
+                let ctx = NaverPresentationContext(window: window)
+                Self._naverContext = ctx
+
+                let session = ASWebAuthenticationSession(
+                    url: authURL, callbackURLScheme: "naverPacing"
+                ) { url, error in
+                    Self._naverSession = nil
+                    Self._naverContext = nil
+                    if let url        { continuation.resume(returning: url) }
+                    else if let error { continuation.resume(throwing: error) }
+                    else              { continuation.resume(throwing: NSError(domain: "NaverLogin", code: -1)) }
+                }
+                session.prefersEphemeralWebBrowserSession = false
+                session.presentationContextProvider = ctx
+                Self._naverSession = session
+                session.start()
+            }
+
+            guard let parts = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false),
+                  let code  = parts.queryItems?.first(where: { $0.name == "code" })?.value
+            else { errorMessage = "네이버 로그인에 실패했어요."; return }
+
+            let functions = Functions.functions(region: "asia-northeast3")
+            let result = try await functions.httpsCallable("naverLogin").call(["code": code, "state": state])
+            guard let data        = result.data as? [String: Any],
+                  let customToken = data["customToken"] as? String
+            else { errorMessage = "네이버 로그인 응답이 올바르지 않아요."; return }
+
+            try await Auth.auth().signIn(withCustomToken: customToken)
+            appState.isLoggedIn = true
+            appState.isAuthLoading = true
+            await restoreProfile(appState: appState)
+        } catch {
+            let nsErr = error as NSError
+            if nsErr.domain == ASWebAuthenticationSessionErrorDomain && nsErr.code == 1 { return }
+            if let msg = Self.koreanAuthError(error) { errorMessage = msg }
+        }
+    }
+
     // MARK: - 카카오 로그인
     func signInWithKakao(appState: AppState) async {
         #if canImport(KakaoSDKUser)
@@ -261,3 +330,31 @@ final class AuthViewModel: ObservableObject {
         return hash.compactMap { String(format: "%02x", $0) }.joined()
     }
 }
+
+// MARK: - ASWebAuthenticationSession context
+final class NaverPresentationContext: NSObject, ASWebAuthenticationPresentationContextProviding {
+    private let window: UIWindow
+    init(window: UIWindow) { self.window = window }
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor { window }
+}
+
+// MARK: - 네이버 SDK Delegate (requestThirdPartyLogin 미사용 시에도 SDK 초기화 필요)
+final class NaverLoginDelegate: NSObject, NaverThirdPartyLoginConnectionDelegate {
+    func oauth20ConnectionDidFinishRequestACTokenWithAuthCode() {
+        guard let token = NaverThirdPartyLoginConnection.getSharedInstance()?.accessToken else {
+            AuthViewModel.naverLoginCompletion?(.failure(NSError(domain: "NaverLogin", code: -1)))
+            return
+        }
+        AuthViewModel.naverLoginCompletion?(.success(token))
+    }
+
+    func oauth20ConnectionDidFinishRequestACTokenWithRefreshToken() {}
+
+    func oauth20ConnectionDidFinishDeleteToken() {}
+
+    func oauth20Connection(_ oauthConnection: NaverThirdPartyLoginConnection!, didFailWithError error: Error!) {
+        AuthViewModel.naverLoginCompletion?(.failure(error ?? NSError(domain: "NaverLogin", code: -2)))
+    }
+}
+
+

--- a/Pacing/Pacing/Features/Auth/View/LoginView.swift
+++ b/Pacing/Pacing/Features/Auth/View/LoginView.swift
@@ -1,11 +1,13 @@
 import SwiftUI
 import AuthenticationServices
 import CryptoKit
+import Combine
 
 struct LoginView: View {
     @EnvironmentObject var appState: AppState
     @StateObject private var authVM = AuthViewModel()
     @State private var navigateToOnboarding = false
+    @Environment(\.scenePhase) private var scenePhase
 
     var body: some View {
         NavigationStack {
@@ -43,6 +45,26 @@ struct LoginView: View {
                             }
                         } prepareNonce: {
                             authVM.prepareNonce()
+                        }
+
+                        // 네이버 로그인
+                        Button {
+                            Task {
+                                await authVM.signInWithNaver(appState: appState)
+                                if appState.isLoggedIn { navigateToOnboarding = true }
+                            }
+                        } label: {
+                            HStack(spacing: 8) {
+                                Image(systemName: "n.circle.fill")
+                                    .font(.system(size: 18))
+                                Text("네이버로 계속하기")
+                            }
+                            .font(.system(size: 16, weight: .medium))
+                            .foregroundStyle(Color.white)
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 50)
+                            .background(Color(red: 0.122, green: 0.8, blue: 0.267))
+                            .clipShape(RoundedRectangle(cornerRadius: 14))
                         }
 
                         // 카카오 로그인
@@ -91,27 +113,6 @@ struct LoginView: View {
                             .clipShape(RoundedRectangle(cornerRadius: 14))
                         }
 
-                        Button {
-                            Task {
-                                await authVM.signInAnonymously(appState: appState)
-                                if appState.isLoggedIn {
-                                    navigateToOnboarding = true
-                                }
-                            }
-                        } label: {
-                            HStack(spacing: 8) {
-                                Image(systemName: "person.fill.questionmark")
-                                Text("게스트로 시작")
-                            }
-                            .font(.system(size: 16, weight: .medium))
-                            .foregroundStyle(.secondary)
-                            .frame(maxWidth: .infinity)
-                            .frame(height: 50)
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 14)
-                                    .stroke(Color(.systemGray4), lineWidth: 1)
-                            )
-                        }
                     }
                     .padding(.horizontal, 24)
                     .padding(.bottom, 48)
@@ -129,6 +130,14 @@ struct LoginView: View {
             .navigationDestination(isPresented: $navigateToOnboarding) {
                 OnboardingPermissionView()
                     .navigationBarBackButtonHidden(true)
+            }
+            .onChange(of: scenePhase) { _, newPhase in
+                if newPhase == .active && authVM.isLoading {
+                    // 외부 로그인(네이버 등) 취소 후 앱으로 돌아왔을 때 로딩 해제
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                        if authVM.isLoading { authVM.isLoading = false }
+                    }
+                }
             }
         }
     }

--- a/Pacing/Pacing/Info.plist
+++ b/Pacing/Pacing/Info.plist
@@ -2,6 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>naversearchapp</string>
+		<string>naversearchapplink</string>
+		<string>navercafe</string>
+	</array>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -22,6 +28,16 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>kakao73e4e7c46ea882a0d78a306b29553c17</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>naver</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>naverPacing</string>
 			</array>
 		</dict>
 	</array>

--- a/Pacing/Pacing/PacingApp.swift
+++ b/Pacing/Pacing/PacingApp.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import FirebaseCore
+import NaverThirdPartyLogin
 #if canImport(GoogleSignIn)
 import GoogleSignIn
 #endif
@@ -16,12 +17,24 @@ import KakaoSDKAuth
 #endif
 
 class AppDelegate: NSObject, UIApplicationDelegate {
+    private let naverDelegate = NaverLoginDelegate()
     func application(_ application: UIApplication,
                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         FirebaseApp.configure()
+
         #if canImport(KakaoSDKCommon)
         KakaoSDK.initSDK(appKey: "73e4e7c46ea882a0d78a306b29553c17")
         #endif
+
+        let naver = NaverThirdPartyLoginConnection.getSharedInstance()
+        naver?.isNaverAppOauthEnable = true
+        naver?.isInAppOauthEnable = true
+        naver?.serviceUrlScheme = "naverPacing"
+        naver?.consumerKey = "hxrh7_6fG3iRc6tKxOuY"
+        naver?.consumerSecret = "l6C67zJ5g2"
+        naver?.appName = "Pacing"
+        naver?.delegate = naverDelegate
+
         return true
     }
 }
@@ -43,6 +56,7 @@ struct PacingApp: App {
                     #if canImport(KakaoSDKAuth)
                     _ = AuthController.handleOpenUrl(url: url)
                     #endif
+                    NaverThirdPartyLoginConnection.getSharedInstance()?.receiveAccessToken(url)
                 }
         }
     }

--- a/doc/fe/feat #14 네이버 로그인 최종 보고서.md
+++ b/doc/fe/feat #14 네이버 로그인 최종 보고서.md
@@ -1,0 +1,54 @@
+# feat #14 네이버 로그인 최종 보고서
+
+## 개요
+- **브랜치**: feat/14-auth-naver-login
+- **목표**: 네이버 아이디로 로그인 기능 추가 (Firebase Custom Token 방식)
+
+---
+
+## 구현 내용
+
+### 1. 네이버 Developers 설정
+- 애플리케이션 등록: iOS 번들 ID `com.eunchan.Pacing`, URL Scheme `naverPacing`
+- PC 웹 환경 추가: 서비스 URL `https://pacing-a8639.web.app`, Callback URL `https://pacing-a8639.web.app/naver-callback`
+
+### 2. Firebase Hosting 중간 리다이렉트
+- `public/naver-callback.html` 배포
+- 네이버가 HTTPS redirect_uri만 허용하므로 Firebase Hosting URL을 Callback으로 등록
+- HTML 페이지가 JS로 `naverPacing://oauth?code=...` 딥링크 생성 → 앱으로 코드 전달
+
+### 3. Cloud Functions `naverLogin`
+- 인증 코드 + state 수신 → 네이버 토큰 API로 access_token 교환
+- `openapi.naver.com/v1/nid/me`로 사용자 정보 조회
+- `admin.auth().createCustomToken(naver:{userId})` 발급 후 반환
+
+### 4. iOS 구현
+- **NaverThirdPartyLogin** SPM 추가 (SDK 초기화)
+- `ASWebAuthenticationSession` OAuth 플로우:
+  - redirect_uri = `https://pacing-a8639.web.app/naver-callback`
+  - callbackURLScheme = `naverPacing`
+  - Firebase Hosting → `naverPacing://oauth?code=...` → ASWebAuthenticationSession 인터셉트
+- Cloud Functions `naverLogin` 호출 → Firebase Custom Token → `signIn(withCustomToken:)`
+- `restoreProfile` → `MainTabView` 진입
+
+### 5. 안정성
+- 로그인 취소/실패 시 `defer`로 `isLoading` 항상 해제
+- `scenePhase` 감지: 앱 포그라운드 복귀 시 1.5초 후 로딩 자동 해제
+
+---
+
+## 해결된 이슈
+- issue-12: 네이버 로그인 미지원 → 해결
+
+---
+
+## 변경 파일
+| 파일 | 변경 내용 |
+|------|-----------|
+| `AuthViewModel.swift` | `signInWithNaver()` 추가, NaverPresentationContext, NaverLoginDelegate |
+| `LoginView.swift` | 네이버 버튼 추가 (초록), 게스트 버튼 제거, scenePhase 로딩 해제 |
+| `PacingApp.swift` | NaverThirdPartyLogin SDK 초기화, onOpenURL 처리 |
+| `Info.plist` | `naverPacing` URL Scheme, `LSApplicationQueriesSchemes` 추가 |
+| `functions/functions/index.js` | `naverLogin` Cloud Function 추가 |
+| `functions/public/naver-callback.html` | Firebase Hosting 리다이렉트 페이지 (신규) |
+| `functions/firebase.json` | hosting 설정 추가, `cleanUrls: true` |

--- a/doc/fe/issues/issue-12 네이버 로그인 미지원.md
+++ b/doc/fe/issues/issue-12 네이버 로그인 미지원.md
@@ -1,0 +1,49 @@
+# issue-12 네이버 로그인 미지원
+
+## 상태
+✅ 해결 완료 (feat #14)
+
+## 문제
+- 로그인 화면에 Apple, Google, 카카오 외 네이버 로그인 미지원
+- 네이버 계정 보유 유저의 접근 불가
+
+## 원인
+- Firebase Auth가 네이버를 네이티브 지원하지 않음
+- Cloud Functions + Custom Token 방식 구현 필요
+- 네이버 OAuth redirect_uri에 커스텀 URL 스킴 불가 → HTTPS 우회 필요
+
+## 해결 방법
+
+### Cloud Functions (Node.js)
+- `naverLogin` HTTPS Callable Function 배포 (asia-northeast3)
+- 인증 코드 → 네이버 토큰 교환 → `openapi.naver.com/v1/nid/me` 사용자 정보 조회
+- `admin.auth().createCustomToken(naverUID)` 발급 후 반환
+
+### Firebase Hosting (중간 리다이렉트)
+- `https://pacing-a8639.web.app/naver-callback` 배포
+- 네이버 OAuth redirect_uri로 HTTPS URL 등록 (네이버 콘솔 요구사항)
+- JS로 `naverPacing://oauth?code=...` 딥링크 → 앱으로 코드 전달
+
+### iOS
+- NaverThirdPartyLogin SDK SPM 추가 (SDK 초기화 용도)
+- `ASWebAuthenticationSession` + Firebase Hosting 리다이렉트 방식
+- `callbackURLScheme = "naverPacing"` → 앱으로 인증 코드 수신
+- `Info.plist`: `naverPacing` URL Scheme, `LSApplicationQueriesSchemes` 추가
+- 로그인 취소/실패 시 `scenePhase` 감지로 로딩 상태 자동 해제
+
+### 발생 이슈 및 해결
+| 이슈 | 원인 | 해결 |
+|------|------|------|
+| 서비스 설정에 오류가 있습니다 | 네이버 콘솔 redirect_uri 미등록 + 서비스 URL 미설정 | PC 웹 환경 추가 및 Callback URL 등록 |
+| 커스텀 URL 스킴 redirect_uri 거부 | 네이버 OAuth 서버가 `naverPacing://` 형식 불허 | Firebase Hosting HTTPS 중간 리다이렉트 도입 |
+| Page Not Found (Firebase Hosting) | `cleanUrls: false`로 `.html` 확장자 필요 | `firebase.json`에 `cleanUrls: true` 추가 |
+| 로그인 실패 후 로딩 고착 | ASWebAuthenticationSession 취소 시 `isLoading` 미해제 | `defer` + `scenePhase` 감지로 1.5초 후 자동 해제 |
+
+## 영향 범위
+- `PacingApp.swift`
+- `AuthViewModel.swift`
+- `LoginView.swift`
+- `Info.plist`
+- `functions/functions/index.js`
+- `functions/public/naver-callback.html` (신규)
+- `functions/firebase.json`

--- a/functions/firebase.json
+++ b/functions/firebase.json
@@ -12,5 +12,14 @@
         "*.local"
       ]
     }
-  ]
+  ],
+  "hosting": {
+    "public": "public",
+    "cleanUrls": true,
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ]
+  }
 }

--- a/functions/functions/index.js
+++ b/functions/functions/index.js
@@ -8,6 +8,66 @@ setGlobalOptions({ maxInstances: 10, region: "asia-northeast3" });
 
 admin.initializeApp();
 
+exports.naverLogin = onCall(async (request) => {
+  logger.info("naverLogin called");
+
+  const { code, state } = request.data;
+  if (!code || !state) {
+    throw new HttpsError("invalid-argument", "code와 state가 필요해요.");
+  }
+
+  // 인증 코드 → 액세스 토큰 교환
+  let accessToken;
+  try {
+    const tokenRes = await axios.get("https://nid.naver.com/oauth2.0/token", {
+      params: {
+        grant_type: "authorization_code",
+        client_id: "hxrh7_6fG3iRc6tKxOuY",
+        client_secret: "l6C67zJ5g2",
+        code,
+        state,
+        redirect_uri: "https://pacing-a8639.web.app/naver-callback",
+      },
+    });
+    accessToken = tokenRes.data.access_token;
+    if (!accessToken) throw new Error("access_token 없음");
+    logger.info("Naver token obtained");
+  } catch (e) {
+    logger.error("Naver token error:", e.response?.data || e.message);
+    throw new HttpsError("unauthenticated", "네이버 인증 코드가 유효하지 않아요.");
+  }
+
+  // 사용자 정보 조회
+  let naverUser;
+  try {
+    const userRes = await axios.get("https://openapi.naver.com/v1/nid/me", {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    naverUser = userRes.data.response;
+    logger.info("Naver user id:", naverUser.id);
+  } catch (e) {
+    logger.error("Naver user API error:", e.response?.data || e.message);
+    throw new HttpsError("unauthenticated", "네이버 사용자 정보를 가져오지 못했어요.");
+  }
+
+  const naverUID = `naver:${naverUser.id}`;
+  const nickname = naverUser.nickname ?? naverUser.name ?? "러너";
+  const profileImage = naverUser.profile_image ?? null;
+
+  try {
+    const customToken = await admin.auth().createCustomToken(naverUID, {
+      provider: "naver",
+      nickname,
+      profileImage,
+    });
+    logger.info("Custom token created for:", naverUID);
+    return { customToken, nickname, profileImage };
+  } catch (e) {
+    logger.error("Custom token error:", e.message);
+    throw new HttpsError("internal", "Custom Token 생성에 실패했어요.");
+  }
+});
+
 exports.kakaoLogin = onCall(async (request) => {
   logger.info("kakaoLogin called");
 

--- a/functions/public/naver-callback.html
+++ b/functions/public/naver-callback.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Pacing</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    background: #f8f8f8;
+    font-family: -apple-system, BlinkMacSystemFont, 'Apple SD Gothic Neo', sans-serif;
+  }
+  .card {
+    background: white;
+    border-radius: 24px;
+    padding: 48px 40px;
+    text-align: center;
+    box-shadow: 0 4px 32px rgba(0,0,0,0.08);
+    max-width: 320px;
+    width: 90%;
+  }
+  .icon {
+    width: 64px;
+    height: 64px;
+    background: #00C73C;
+    border-radius: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0 auto 20px;
+    font-size: 32px;
+  }
+  .app-name {
+    font-size: 22px;
+    font-weight: 700;
+    color: #111;
+    margin-bottom: 8px;
+  }
+  .message {
+    font-size: 14px;
+    color: #888;
+    line-height: 1.6;
+    margin-bottom: 28px;
+  }
+  .spinner {
+    width: 28px;
+    height: 28px;
+    border: 3px solid #e0e0e0;
+    border-top-color: #00C73C;
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+    margin: 0 auto;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  .error { color: #e74c3c; font-size: 14px; }
+</style>
+</head>
+<body>
+<div class="card">
+  <div class="icon">🏃</div>
+  <div class="app-name">Pacing</div>
+  <div class="message" id="msg">네이버 로그인 처리 중이에요.<br>잠시만 기다려주세요.</div>
+  <div class="spinner" id="spinner"></div>
+</div>
+<script>
+  var params = new URLSearchParams(window.location.search);
+  var code = params.get('code');
+  var state = params.get('state');
+  if (code && state) {
+    setTimeout(function() {
+      window.location.href = 'naverPacing://oauth?code=' + encodeURIComponent(code) + '&state=' + encodeURIComponent(state);
+    }, 300);
+  } else {
+    document.getElementById('spinner').style.display = 'none';
+    document.getElementById('msg').innerHTML = '<span class="error">오류가 발생했습니다.<br>앱으로 돌아가 다시 시도해주세요.</span>';
+  }
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- ASWebAuthenticationSession + Firebase Hosting 리다이렉트 방식으로 네이버 OAuth 구현
- `naverLogin` Cloud Function 추가 (인증 코드 → 네이버 토큰 교환 → Firebase Custom Token)
- 네이버 Developers: iOS URL Scheme `naverPacing`, PC 웹 Callback URL 등록
- 게스트 로그인 버튼 제거
- 로그인 실패/취소 시 `defer` + `scenePhase` 감지로 로딩 상태 자동 해제

## Test plan
- [ ] 네이버 로그인 버튼 탭 → ASWebAuthenticationSession 웹뷰 열림
- [ ] 네이버 계정 선택 → Firebase Hosting 리다이렉트 → 앱 복귀 → MainTabView 진입
- [ ] 로그인 취소(X) 후 로그인 버튼 다시 표시 확인
- [ ] 재로그인 시 프로필 재입력 없이 바로 진입 확인
- [ ] Apple, Google, 카카오 로그인 정상 동작 회귀 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)