### PR TITLE
fix: 노래 탭 alert 상태 업데이트 경고 수정

### DIFF
--- a/Pacing/Pacing/Features/Share/View/SongView.swift
+++ b/Pacing/Pacing/Features/Share/View/SongView.swift
@@ -53,7 +53,7 @@ struct SongView: View {
                     }
                     .refreshable { await vm.load() }
                     .alert("노래 탭 오류", isPresented: errorBinding) {
-                        Button("확인", role: .cancel) { vm.errorMessage = nil }
+                        Button("확인", role: .cancel) { dismissErrorMessage() }
                     } message: {
                         Text(vm.errorMessage ?? "")
                     }
@@ -389,8 +389,14 @@ struct SongView: View {
     private var errorBinding: Binding<Bool> {
         Binding(
             get: { vm.errorMessage != nil },
-            set: { if !$0 { vm.errorMessage = nil } }
+            set: { if !$0 { dismissErrorMessage() } }
         )
+    }
+
+    private func dismissErrorMessage() {
+        DispatchQueue.main.async {
+            vm.errorMessage = nil
+        }
     }
 
     private var mainOffsetReader: some View {


### PR DESCRIPTION
## 개요
노래 탭 alert dismiss 시점에 SwiftUI view update 중 `@Published` 상태가 변경되며 발생하던 경고를 수정했습니다.
로컬 AppIcon 설정은 최신 `dev`의 정상 상태로 정리했습니다.

## 변경 사항
- `SongView`의 alert 확인 버튼과 `isPresented` Binding setter가 공통 dismiss 함수를 사용하도록 정리
- `vm.errorMessage = nil` 변경을 다음 main queue 턴에서 실행해 SwiftUI view update 중 publish 경고 방지
- 잘못 staged 되어 있던 AppIcon 로컬 변경 제거

## QA
- `git diff --check` 통과
- AppIcon `Contents.json`이 `dev` 정상 상태를 참조하는 것 확인
- 터미널 `xcodebuild`는 현재 active developer directory가 CommandLineTools라 실행 불가
- Xcode에서 직접 빌드 확인 필요