### PR TITLE
fix: Firestore 프로덕션 보안 규칙 적용

### DIFF
--- a/Pacing/Pacing/Core/Firebase/FirestoreService.swift
+++ b/Pacing/Pacing/Core/Firebase/FirestoreService.swift
@@ -1,10 +1,12 @@
 import Foundation
 import FirebaseFirestore
+import FirebaseFunctions
 import CoreLocation
 
 final class FirestoreService {
     static let shared = FirestoreService()
     private let db = Firestore.firestore()
+    private let functions = Functions.functions(region: "asia-northeast3")
 
     private init() {}
 
@@ -359,33 +361,10 @@ final class FirestoreService {
 
     // MARK: - 친구 요청 수락
     func acceptFriendRequest(_ request: FriendRequest, currentUserNickname: String) async throws {
-        let fromUser = request.sender
-        let currentUser = try await fetchFriendUser(uid: request.toUID, source: .friend)
-
-        let batch = db.batch()
-        let requestRef = db.collection("friendRequests").document(request.id)
-        let myFriendRef = db.collection("users").document(request.toUID)
-            .collection("friends").document(request.fromUID)
-        let senderFriendRef = db.collection("users").document(request.fromUID)
-            .collection("friends").document(request.toUID)
-
-        batch.setData(friendDocumentData(from: fromUser), forDocument: myFriendRef, merge: true)
-        batch.setData(
-            friendDocumentData(
-                from: FriendUser(
-                    id: currentUser.id,
-                    nickname: currentUser.nickname.isEmpty ? currentUserNickname : currentUser.nickname,
-                    profileImageBase64: currentUser.profileImageBase64,
-                    statusText: currentUser.statusText,
-                    source: .friend
-                )
-            ),
-            forDocument: senderFriendRef,
-            merge: true
-        )
-        batch.updateData(["status": FriendRequestStatus.accepted.rawValue], forDocument: requestRef)
-
-        try await batch.commit()
+        _ = currentUserNickname
+        _ = try await functions
+            .httpsCallable("acceptFriendRequest")
+            .call(["requestID": request.id])
     }
 
     // MARK: - 친구 요청 거절
@@ -532,19 +511,6 @@ final class FirestoreService {
             statusText: FriendActivityText.runningStatus(lastRunDate: lastRunDate),
             source: source
         )
-    }
-
-    private func friendDocumentData(from user: FriendUser) -> [String: Any] {
-        var data: [String: Any] = [
-            "uid": user.id,
-            "nickname": user.nickname,
-            "statusText": user.statusText,
-            "createdAt": FieldValue.serverTimestamp()
-        ]
-        if let profileImageBase64 = user.profileImageBase64 {
-            data["profileImageBase64"] = profileImageBase64
-        }
-        return data
     }
 
     private func makeSharedPlaylistSummary(from doc: DocumentSnapshot) -> SharedPlaylistSummary? {

--- a/functions/firebase.json
+++ b/functions/firebase.json
@@ -13,6 +13,9 @@
       ]
     }
   ],
+  "firestore": {
+    "rules": "firestore.rules"
+  },
   "hosting": {
     "public": "public",
     "cleanUrls": true,

--- a/functions/firestore.rules
+++ b/functions/firestore.rules
@@ -1,0 +1,83 @@
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // 테스트 모드의 전체 공개를 대체합니다. 모든 클라이언트 요청은 Firebase
+    // Authentication 로그인이 선행되어야 합니다.
+    function signedIn() {
+      return request.auth != null;
+    }
+
+    function isOwner(uid) {
+      return signedIn() && request.auth.uid == uid;
+    }
+
+    // 친구의 러닝/최근 음악 정보는 상호 친구 문서가 존재할 때만 조회할 수 있습니다.
+    function isFriendOf(uid) {
+      return signedIn()
+        && exists(/databases/$(database)/documents/users/$(uid)/friends/$(request.auth.uid));
+    }
+
+    match /users/{userId} {
+      // 현재 앱은 닉네임 검색·친구 추천을 위해 사용자 문서를 조회합니다.
+      // 쓰기는 반드시 본인 문서에만 허용합니다.
+      allow read: if signedIn();
+      allow create, update, delete: if isOwner(userId);
+
+      match /runHistory/{recordId} {
+        allow read: if isOwner(userId) || isFriendOf(userId);
+        allow create, update, delete: if isOwner(userId);
+      }
+
+      match /recentSongs/{songId} {
+        allow read: if isOwner(userId) || isFriendOf(userId);
+        allow create, update, delete: if isOwner(userId);
+      }
+
+      match /friends/{friendId} {
+        allow read: if isOwner(userId);
+        allow create, update, delete: if isOwner(userId);
+      }
+
+      match /savedSharedPlaylists/{playlistId} {
+        allow read, write: if isOwner(userId);
+      }
+    }
+
+    match /friendRequests/{requestId} {
+      allow read: if signedIn()
+        && (resource.data.fromUID == request.auth.uid || resource.data.toUID == request.auth.uid);
+
+      allow create: if signedIn()
+        && request.resource.data.fromUID == request.auth.uid
+        && request.resource.data.toUID is string
+        && request.resource.data.toUID != request.auth.uid
+        && request.resource.data.status == 'pending';
+
+      // 발신자는 취소(거절)할 수 있고, 수신자는 수락 또는 거절할 수 있습니다.
+      // 요청의 당사자와 상태 외의 필드는 수정할 수 없습니다.
+      allow update: if signedIn()
+        && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['status'])
+        && (
+          (resource.data.fromUID == request.auth.uid && request.resource.data.status == 'rejected')
+          || (resource.data.toUID == request.auth.uid && request.resource.data.status in ['accepted', 'rejected'])
+        );
+
+      allow delete: if false;
+    }
+
+    match /sharedPlaylists/{playlistId} {
+      allow read: if signedIn();
+      allow create: if signedIn() && request.resource.data.ownerUID == request.auth.uid;
+      allow update: if signedIn()
+        && resource.data.ownerUID == request.auth.uid
+        && request.resource.data.ownerUID == resource.data.ownerUID;
+      allow delete: if signedIn() && resource.data.ownerUID == request.auth.uid;
+    }
+
+    // 명시하지 않은 모든 경로는 기본 거부입니다.
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/functions/functions/index.js
+++ b/functions/functions/index.js
@@ -103,6 +103,75 @@ exports.deleteAccount = onCall(async (request) => {
   }
 });
 
+/**
+ * Accepts an incoming friend request and creates the reciprocal friend records.
+ * Admin SDK writes bypass client rules so a recipient cannot forge access to a
+ * different user's friend list from the iOS client.
+ */
+exports.acceptFriendRequest = onCall(async (request) => {
+  const uid = request.auth?.uid;
+  const requestID = request.data?.requestID;
+  if (!uid) {
+    throw new HttpsError("unauthenticated", "로그인한 사용자만 친구 요청을 수락할 수 있어요.");
+  }
+  if (!requestID || typeof requestID !== "string") {
+    throw new HttpsError("invalid-argument", "친구 요청 ID가 필요해요.");
+  }
+
+  const requestRef = firestore.collection("friendRequests").doc(requestID);
+  const friendProfile = (user, fallbackNickname) => ({
+    uid: user.id,
+    nickname: user.get("nickname") || fallbackNickname,
+    statusText: "최근 활동 없음",
+    createdAt: admin.firestore.FieldValue.serverTimestamp(),
+    ...(user.get("profileImageBase64") ? { profileImageBase64: user.get("profileImageBase64") } : {}),
+  });
+
+  try {
+    await firestore.runTransaction(async (transaction) => {
+      const friendRequest = await transaction.get(requestRef);
+      if (!friendRequest.exists) {
+        throw new HttpsError("not-found", "친구 요청을 찾을 수 없어요.");
+      }
+
+      const data = friendRequest.data();
+      if (data.toUID !== uid || data.status !== "pending") {
+        throw new HttpsError("permission-denied", "수락할 수 없는 친구 요청이에요.");
+      }
+
+      const senderRef = firestore.collection("users").doc(data.fromUID);
+      const recipientRef = firestore.collection("users").doc(uid);
+      const [sender, recipient] = await Promise.all([
+        transaction.get(senderRef),
+        transaction.get(recipientRef),
+      ]);
+
+      transaction.set(
+        recipientRef.collection("friends").doc(data.fromUID),
+        friendProfile(sender, "러너"),
+        { merge: true },
+      );
+      transaction.set(
+        senderRef.collection("friends").doc(uid),
+        friendProfile(recipient, "러너"),
+        { merge: true },
+      );
+      transaction.update(requestRef, { status: "accepted" });
+    });
+
+    return { accepted: true };
+  } catch (error) {
+    if (error instanceof HttpsError) throw error;
+    logger.error("Friend request acceptance failed", {
+      uid,
+      requestID,
+      errorCode: error?.code,
+      errorMessage: error?.message,
+    });
+    throw new HttpsError("internal", "친구 요청을 수락하지 못했어요. 잠시 후 다시 시도해 주세요.");
+  }
+});
+
 exports.naverLogin = onCall(async (request) => {
   logger.info("naverLogin called");
 


### PR DESCRIPTION
## 작업 보고서

테스트 모드 만료로 발생할 수 있는 Firestore 클라이언트 요청 차단을 해소하고, 프로덕션용 접근 제어를 적용했습니다.

### 변경 사항

- `firestore.rules` 추가 및 Firebase 배포 설정 등록
- 모든 Firestore 요청에 Firebase Authentication 인증 요구
- 사용자 문서는 본인만 수정, 러닝 기록·최근 음악은 본인 또는 친구만 조회 가능
- 친구 요청의 생성·수락·거절 권한 및 변경 가능 필드 제한
- 공유 플레이리스트의 소유자 변경 방지
- 친구 수락 시 양쪽 친구 문서를 생성하는 `acceptFriendRequest` Callable Function 추가
- iOS 클라이언트의 친구 수락을 서버 Callable Function 호출로 변경

### 데이터 영향

Firestore 데이터 삭제, 초기화, 스키마 마이그레이션은 수행하지 않았습니다. 기존 사용자·러닝 기록·친구·플레이리스트 데이터는 유지됩니다.

### 검증

- `node --check functions/index.js` 통과
- `git diff --check` 통과
- Firestore 규칙 컴파일 및 `pacing-a8639` 프로덕션 배포 완료
- `acceptFriendRequest` 함수(asia-northeast3) 배포 상태 확인

### 참고

전체 Xcode 빌드는 작업 환경에 Xcode가 설치되어 있지 않아 실행하지 못했습니다. iOS 앱 릴리스 전 친구 요청 수락 흐름을 실기기 또는 Firebase Emulator로 확인해야 합니다.