### PR TITLE
refactor: DateFormatter 힙 할당 제거

### DIFF
--- a/Pacing/Pacing/Features/My/View/RunHistoryCard.swift
+++ b/Pacing/Pacing/Features/My/View/RunHistoryCard.swift
@@ -5,17 +5,11 @@ struct RunHistoryCard: View {
     let vm: MyViewModel
 
     private var dateString: String {
-        let f = DateFormatter()
-        f.locale = Locale(identifier: "ko_KR")
-        f.dateFormat = "yyyy. M. d."
-        return f.string(from: record.startedAt)
+        RunHistoryDateFormatters.date.string(from: record.startedAt)
     }
 
     private var startTimeString: String {
-        let f = DateFormatter()
-        f.locale = Locale(identifier: "ko_KR")
-        f.dateFormat = "a h시 m분"
-        return f.string(from: record.startedAt)
+        RunHistoryDateFormatters.startTime.string(from: record.startedAt)
     }
 
     var body: some View {
@@ -61,5 +55,18 @@ struct RunHistoryCard: View {
                 .font(.system(size: 11))
                 .foregroundStyle(Color.textSecondary)
         }
+    }
+}
+
+@MainActor
+private enum RunHistoryDateFormatters {
+    static let date = make(format: "yyyy. M. d.")
+    static let startTime = make(format: "a h시 m분")
+
+    private static func make(format: String) -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = format
+        return formatter
     }
 }

--- a/doc/refactoring/refactor-123-heap-allocation-avoidance/01-date-formatter/after.md
+++ b/doc/refactoring/refactor-123-heap-allocation-avoidance/01-date-formatter/after.md
@@ -1,0 +1,7 @@
+# After — DateFormatter Allocation
+
+날짜·시간 형식별 `DateFormatter`를 `@MainActor` 정적 캐시로 한 번 생성해 재사용한다. `RunHistoryCard`는 메인 액터의 SwiftUI 렌더링 경로에서만 이를 사용하므로, `DateFormatter`의 동시 접근을 만들지 않는다.
+
+릴리스 최적화(`-O`)에서 1,000개 날짜를 포맷한 순수 벤치마크를 세 번 독립 실행했다. 중앙값은 `48.54903 ms → 2.77150 ms`로, **94.3% 개선**이다. before/after가 만든 날짜·시간 문자열 2,000개 전체가 같은지 `precondition`으로 검증했다.
+
+이 값은 `DateFormatter` 생성·설정과 문자열 생성 구간의 마이크로벤치마크다. SwiftUI 레이아웃·텍스트 렌더링 시간은 포함하지 않는다.

--- a/doc/refactoring/refactor-123-heap-allocation-avoidance/01-date-formatter/before.md
+++ b/doc/refactoring/refactor-123-heap-allocation-avoidance/01-date-formatter/before.md
@@ -1,0 +1,3 @@
+# Before — DateFormatter Allocation
+
+`RunHistoryCard`의 `dateString`, `startTimeString`은 호출할 때마다 각각 `DateFormatter`를 생성하고 locale·format을 설정했다. SwiftUI가 목록 셀을 다시 그릴 때마다 두 Foundation 객체의 힙 할당과 초기화가 반복된다.

--- a/doc/refactoring/refactor-123-heap-allocation-avoidance/README.md
+++ b/doc/refactoring/refactor-123-heap-allocation-avoidance/README.md
@@ -1,0 +1,26 @@
+# Heap Allocation Avoidance 리팩토링 계획서
+
+> 상태: 구현·벤치마크 완료 / 컴파일 QA 진행 중
+> 작성일: 2026-08-22
+> 관련 이슈: [#123 Heap Allocation Avoidance 최적화](https://github.com/kec08/Pacing/issues/123)
+> 브랜치: `refactor/123`
+
+## 대상
+
+| 대상 코드 | Before 병목 | 변경 방향 |
+| --- | --- | --- |
+| `RunHistoryCard` 날짜·시간 표시 | SwiftUI body 재평가마다 `DateFormatter` 2개 생성 | 메인 액터 정적 캐시 재사용 |
+
+## 검증 기준
+
+- 동일 날짜에서 before/after 문자열이 같아야 한다.
+- 릴리스 최적화 벤치마크로 포맷터 생성·사용 비용을 비교한다.
+- UI 렌더링·네트워크 시간은 측정 범위에서 제외한다.
+
+## 측정 결과
+
+릴리스 최적화(`-O`)에서 1,000개 날짜를 15개 표본(표본당 5회)으로 측정했다. 세 번 독립 실행한 중앙값을 기록했으며, before/after가 만든 2,000개 문자열 배열 전체의 동등성을 `precondition`으로 검증했다.
+
+| 대상 | Before | After | 개선 |
+| --- | ---: | ---: | ---: |
+| `RunHistoryCard` 날짜·시간 포맷 | 48.54903 ms | 2.77150 ms | 94.3% |

--- a/doc/refactoring/refactor-123-heap-allocation-avoidance/benchmark.swift
+++ b/doc/refactoring/refactor-123-heap-allocation-avoidance/benchmark.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+private let inputCount = 1_000
+private let repetitionsPerSample = 5
+private let sampleCount = 15
+private let locale = Locale(identifier: "ko_KR")
+private let dates = (0..<inputCount).map {
+    Date(timeIntervalSinceReferenceDate: TimeInterval($0 * 3_601))
+}
+
+private let cachedDateFormatter = makeFormatter("yyyy. M. d.")
+private let cachedStartTimeFormatter = makeFormatter("a h시 m분")
+
+private func makeFormatter(_ format: String) -> DateFormatter {
+    let formatter = DateFormatter()
+    formatter.locale = locale
+    formatter.dateFormat = format
+    return formatter
+}
+
+@inline(never) private func before() -> [String] {
+    dates.flatMap { date -> [String] in
+        let dateFormatter = makeFormatter("yyyy. M. d.")
+        let timeFormatter = makeFormatter("a h시 m분")
+        return [dateFormatter.string(from: date), timeFormatter.string(from: date)]
+    }
+}
+
+@inline(never) private func after() -> [String] {
+    dates.flatMap { date in
+        [cachedDateFormatter.string(from: date), cachedStartTimeFormatter.string(from: date)]
+    }
+}
+
+private func median(_ values: [Double]) -> Double {
+    values.sorted()[values.count / 2]
+}
+
+private func measure(_ body: () -> [String]) -> Double {
+    let expected = before()
+    precondition(body() == expected)
+
+    let samples = (0..<sampleCount).map { _ -> Double in
+        let start = DispatchTime.now().uptimeNanoseconds
+        for _ in 0..<repetitionsPerSample { precondition(body() == expected) }
+        return Double(DispatchTime.now().uptimeNanoseconds - start) / 1_000_000 / Double(repetitionsPerSample)
+    }
+    return median(samples)
+}
+
+let beforeMilliseconds = measure(before)
+let afterMilliseconds = measure(after)
+let improvement = (1 - afterMilliseconds / beforeMilliseconds) * 100
+
+print("before_ms=\(beforeMilliseconds) after_ms=\(afterMilliseconds) improvement=\(improvement)")


### PR DESCRIPTION
## 요약
- `RunHistoryCard` 렌더링 시마다 생성되던 날짜·시간 `DateFormatter`를 메인 액터 정적 캐시로 재사용
- 1,000개 날짜 포맷 마이크로벤치마크와 Before/After 문서 추가

## 성능
- `48.54903 ms → 2.77150 ms`
- **94.3% 개선** (DateFormatter 생성·설정 및 문자열 생성 구간)

## 검증
- before/after 2,000개 문자열 배열 완전 동등성 `precondition` 검증
- `xcodebuild build-for-testing -project Pacing/Pacing.xcodeproj -scheme Pacing -sdk iphonesimulator` 통과
- Simulator XCTest는 런타임 종료 환경 문제로 실행하지 못함

Closes #123