### PR TITLE
feat: 결과 화면 고도 및 HealthKit 심박수 연동

### DIFF
--- a/Pacing/Pacing/Core/Firebase/FirestoreService.swift
+++ b/Pacing/Pacing/Core/Firebase/FirestoreService.swift
@@ -79,6 +79,15 @@ final class FirestoreService {
         data["lapPaces"] = record.lapPaces.map {
             ["kilometer": $0.kilometer, "pace": $0.pace]
         }
+        if let elevationGainMeters = record.elevationGainMeters {
+            data["elevationGainMeters"] = elevationGainMeters
+        }
+        if let averageHeartRate = record.averageHeartRate {
+            data["averageHeartRate"] = averageHeartRate
+        }
+        if let averageCadence = record.averageCadence {
+            data["averageCadence"] = averageCadence
+        }
 
         try await db.collection("users").document(uid)
             .collection("runHistory").document(record.id)
@@ -101,6 +110,9 @@ final class FirestoreService {
             let duration = (d["duration"] as? NSNumber)?.intValue ?? 0
             let distance = (d["distance"] as? NSNumber)?.doubleValue ?? 0
             let avgPace  = (d["avgPace"]  as? NSNumber)?.doubleValue ?? 0
+            let elevationGainMeters = (d["elevationGainMeters"] as? NSNumber)?.doubleValue
+            let averageHeartRate = (d["averageHeartRate"] as? NSNumber)?.doubleValue
+            let averageCadence = (d["averageCadence"] as? NSNumber)?.doubleValue
 
             let geoPoints = (d["routeCoordinates"] as? [GeoPoint]) ?? []
             let coords = geoPoints.map {
@@ -123,7 +135,10 @@ final class FirestoreService {
                 distance: distance,
                 avgPace: avgPace,
                 routeCoordinates: coords,
-                lapPaces: lapPaces
+                lapPaces: lapPaces,
+                elevationGainMeters: elevationGainMeters,
+                averageHeartRate: averageHeartRate,
+                averageCadence: averageCadence
             )
         }
     }

--- a/Pacing/Pacing/Core/Health/HealthKitHeartRateRepository.swift
+++ b/Pacing/Pacing/Core/Health/HealthKitHeartRateRepository.swift
@@ -1,0 +1,90 @@
+import Foundation
+import HealthKit
+
+protocol HeartRateRepository {
+    func requestReadAuthorization() async -> Bool
+    func averageHeartRate(from startDate: Date, to endDate: Date) async -> Double?
+}
+
+final class HealthKitHeartRateRepository: HeartRateRepository {
+    private let healthStore: HKHealthStore?
+
+    init(healthStore: HKHealthStore? = HKHealthStore.isHealthDataAvailable() ? HKHealthStore() : nil) {
+        self.healthStore = healthStore
+    }
+
+    func requestReadAuthorization() async -> Bool {
+        guard let healthStore else { return false }
+        guard let heartRateType = HKObjectType.quantityType(forIdentifier: .heartRate) else {
+            return false
+        }
+
+        do {
+            try await healthStore.requestAuthorization(toShare: [], read: [heartRateType])
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    func averageHeartRate(from startDate: Date, to endDate: Date) async -> Double? {
+        guard let healthStore,
+              let heartRateType = HKObjectType.quantityType(forIdentifier: .heartRate),
+              startDate < endDate
+        else { return nil }
+
+        let predicate = HKQuery.predicateForSamples(
+            withStart: startDate,
+            end: endDate,
+            options: .strictStartDate
+        )
+
+        return await withCheckedContinuation { continuation in
+            let query = HKSampleQuery(
+                sampleType: heartRateType,
+                predicate: predicate,
+                limit: HKObjectQueryNoLimit,
+                sortDescriptors: [NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: true)]
+            ) { [weak self] _, samples, _ in
+                guard let self else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+
+                let heartRateSamples = (samples as? [HKQuantitySample] ?? [])
+                    .filter { self.isValidHeartRateSample($0) }
+
+                // Apple Watch 샘플을 우선 사용하고, Watch가 식별되지 않는 환경에서는
+                // HealthKit의 유효 심박수 샘플을 fallback으로 사용한다.
+                let watchSamples = heartRateSamples.filter { self.isAppleWatchSample($0) }
+                let selectedSamples = watchSamples.isEmpty ? heartRateSamples : watchSamples
+                guard !selectedSamples.isEmpty else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+
+                let unit = HKUnit.count().unitDivided(by: HKUnit.minute())
+                let average = selectedSamples
+                    .map { $0.quantity.doubleValue(for: unit) }
+                    .reduce(0, +) / Double(selectedSamples.count)
+                continuation.resume(returning: average.isFinite ? average : nil)
+            }
+            healthStore.execute(query)
+        }
+    }
+
+    private func isValidHeartRateSample(_ sample: HKQuantitySample) -> Bool {
+        let unit = HKUnit.count().unitDivided(by: HKUnit.minute())
+        let bpm = sample.quantity.doubleValue(for: unit)
+        return bpm.isFinite && (30...240).contains(bpm)
+    }
+
+    private func isAppleWatchSample(_ sample: HKQuantitySample) -> Bool {
+        let deviceName = sample.device?.name ?? ""
+        let deviceModel = sample.device?.model ?? ""
+        let sourceName = sample.sourceRevision.source.name
+        return [deviceName, deviceModel, sourceName].contains {
+            $0.localizedCaseInsensitiveContains("watch")
+        }
+    }
+}

--- a/Pacing/Pacing/Core/Location/LocationManager.swift
+++ b/Pacing/Pacing/Core/Location/LocationManager.swift
@@ -192,8 +192,8 @@ extension LocationManager: CLLocationManagerDelegate {
             return
         }
 
-        recentRecordedLocations = recordedLocations
         self.recordedLocations.append(contentsOf: recordedLocations)
+        recentRecordedLocations = recordedLocations
         appendRouteCoordinates(from: recordedLocations)
     }
 

--- a/Pacing/Pacing/Core/Location/LocationManager.swift
+++ b/Pacing/Pacing/Core/Location/LocationManager.swift
@@ -36,6 +36,7 @@ final class LocationManager: NSObject, ObservableObject {
     @Published var authorizationStatus: CLAuthorizationStatus = .notDetermined
     @Published var routeCoordinates: [CLLocationCoordinate2D] = []
     @Published private(set) var recentRecordedLocations: [CLLocation] = []
+    @Published private(set) var recordedLocations: [CLLocation] = []
 
     private let manager = CLLocationManager()
     private var isRecordingRoute = false
@@ -101,6 +102,7 @@ final class LocationManager: NSObject, ObservableObject {
         isRecordingRoute = false
         routeCoordinates = []
         recentRecordedLocations = []
+        recordedLocations = []
         configureBackgroundLocationSupport()
     }
 
@@ -191,6 +193,7 @@ extension LocationManager: CLLocationManagerDelegate {
         }
 
         recentRecordedLocations = recordedLocations
+        self.recordedLocations.append(contentsOf: recordedLocations)
         appendRouteCoordinates(from: recordedLocations)
     }
 

--- a/Pacing/Pacing/Features/Running/View/RunActivityDetailView.swift
+++ b/Pacing/Pacing/Features/Running/View/RunActivityDetailView.swift
@@ -61,10 +61,17 @@ struct RunActivityDetailView: View {
     }
 
     private var metricsSection: some View {
-        HStack(alignment: .top, spacing: 12) {
-            compactMetric(value: formattedPace(record.displayPace), label: "평균 페이스")
-            compactMetric(value: formattedDuration(record.duration), label: "시간")
-            compactMetric(value: "\(estimatedCalories)", label: "칼로리")
+        VStack(spacing: 18) {
+            HStack(alignment: .top, spacing: 12) {
+                compactMetric(value: formattedPace(record.displayPace), label: "평균 페이스")
+                compactMetric(value: formattedDuration(record.duration), label: "시간")
+                compactMetric(value: "\(estimatedCalories)", label: "칼로리")
+            }
+            HStack(alignment: .top, spacing: 12) {
+                compactMetric(value: formattedElevation, label: "고도 상승")
+                compactMetric(value: formattedHeartRate, label: "BPM")
+                compactMetric(value: "--", label: "케이던스")
+            }
         }
     }
 
@@ -206,6 +213,16 @@ struct RunActivityDetailView: View {
         let storedWeight = UserDefaults.standard.integer(forKey: "weight")
         let weight = storedWeight > 0 ? Double(storedWeight) : 60.0
         return Int((weight * record.distance * 1.036).rounded())
+    }
+
+    private var formattedElevation: String {
+        guard let value = record.elevationGainMeters, value.isFinite else { return "--" }
+        return "\(Int(value.rounded())) m"
+    }
+
+    private var formattedHeartRate: String {
+        guard let value = record.averageHeartRate, value.isFinite else { return "--" }
+        return "\(Int(value.rounded()))"
     }
 
     private func formattedDuration(_ seconds: Int) -> String {

--- a/Pacing/Pacing/Features/Running/View/RunSummaryView.swift
+++ b/Pacing/Pacing/Features/Running/View/RunSummaryView.swift
@@ -9,6 +9,8 @@ struct RunSummaryView: View {
     let calories: Int
     let lapPaces: [RunLapPace]
     let routeCoordinates: [CLLocationCoordinate2D]
+    let elevationGainMeters: Double?
+    let averageHeartRate: Double?
     let onSave: () -> Void
     let onDiscard: () -> Void
 
@@ -98,6 +100,14 @@ struct RunSummaryView: View {
                 subStatItem(value: formattedCalories, label: "칼로리", minimumScaleFactor: 0.55)
             }
 
+            Divider().opacity(0.3).padding(.vertical, 14)
+
+            HStack(spacing: 0) {
+                subStatItem(value: formattedElevation, label: "고도 상승")
+                subStatItem(value: formattedHeartRate, label: "BPM")
+                subStatItem(value: "--", label: "케이던스")
+            }
+
             if !lapPaces.isEmpty {
                 Divider().opacity(0.3).padding(.vertical, 14)
 
@@ -168,6 +178,16 @@ struct RunSummaryView: View {
 
     private var formattedCalories: String {
         "\(calories) kcal"
+    }
+
+    private var formattedElevation: String {
+        guard let elevationGainMeters, elevationGainMeters.isFinite else { return "--" }
+        return "\(Int(elevationGainMeters.rounded())) m"
+    }
+
+    private var formattedHeartRate: String {
+        guard let averageHeartRate, averageHeartRate.isFinite else { return "--" }
+        return "\(Int(averageHeartRate.rounded()))"
     }
 
     private func formattedPace(_ pace: Double) -> String {

--- a/Pacing/Pacing/Features/Running/View/RunningView.swift
+++ b/Pacing/Pacing/Features/Running/View/RunningView.swift
@@ -360,19 +360,25 @@ struct RunningView: View {
                 calories: viewModel.estimatedCalories,
                 lapPaces: viewModel.completedLapPaces,
                 routeCoordinates: viewModel.locationManager.routeCoordinates,
+                elevationGainMeters: viewModel.elevationGainMeters,
+                averageHeartRate: viewModel.averageHeartRate,
                 onSave: {
                     let savedDistance = viewModel.distance
                     let savedElapsedSeconds = viewModel.elapsedSeconds
                     let savedAveragePace = viewModel.avgPace
                     let savedRouteCoordinates = viewModel.locationManager.routeCoordinates
                     let savedLapPaces = viewModel.completedLapPaces
+                    let savedElevationGainMeters = viewModel.elevationGainMeters
+                    let savedAverageHeartRate = viewModel.averageHeartRate
                     Task {
                         await viewModel.saveRecord(
                             distance: savedDistance,
                             elapsedSeconds: savedElapsedSeconds,
                             avgPace: savedAveragePace,
                             routeCoordinates: savedRouteCoordinates,
-                            lapPaces: savedLapPaces
+                            lapPaces: savedLapPaces,
+                            elevationGainMeters: savedElevationGainMeters,
+                            averageHeartRate: savedAverageHeartRate
                         )
                     }
                     showSummary = false
@@ -842,10 +848,12 @@ struct RunningView: View {
                     stopHoldTimer?.invalidate()
                     stopHoldTimer = nil
                     UINotificationFeedbackGenerator().notificationOccurred(.success)
-                    viewModel.stop()
-                    showSummary = true
-                    showStopConfirm = false
-                    stopHoldProgress = 0
+                    Task {
+                        await viewModel.stop()
+                        showSummary = true
+                        showStopConfirm = false
+                        stopHoldProgress = 0
+                    }
                 }
             }
         }

--- a/Pacing/Pacing/Features/Running/View/RunningView.swift
+++ b/Pacing/Pacing/Features/Running/View/RunningView.swift
@@ -548,7 +548,7 @@ struct RunningView: View {
         HStack(spacing: 0) {
             independentMetricButton(
                 index: $leftMetricIndex,
-                values: [(viewModel.formattedDistance, "km"), ("--", "고도 상승")]
+                values: [(viewModel.formattedDistance, "km"), (viewModel.formattedElevationGain, "고도 상승")]
             )
             metricDivider
             independentMetricButton(
@@ -638,7 +638,7 @@ struct RunningView: View {
             HStack(spacing: 0) {
                 pausedMetric(value: viewModel.formattedCalories, label: "칼로리")
                 metricDivider
-                pausedMetric(value: "--", label: "고도 상승")
+                pausedMetric(value: viewModel.formattedElevationGain, label: "고도 상승")
                 metricDivider
                 pausedMetric(value: "--", label: "BPM")
             }

--- a/Pacing/Pacing/Features/Running/ViewModel/RunningViewModel.swift
+++ b/Pacing/Pacing/Features/Running/ViewModel/RunningViewModel.swift
@@ -265,6 +265,10 @@ final class RunningViewModel: ObservableObject {
         if hasDistanceChanged {
             updateDisplayedPace()
         }
+
+        elevationGainMeters = RunMetricsCalculator.elevationGain(
+            from: locationManager.recordedLocations
+        ) ?? 0
     }
 
     func saveRecord(

--- a/Pacing/Pacing/Features/Running/ViewModel/RunningViewModel.swift
+++ b/Pacing/Pacing/Features/Running/ViewModel/RunningViewModel.swift
@@ -48,6 +48,8 @@ final class RunningViewModel: ObservableObject {
     @Published var distance: Double = 0       // km
     @Published var currentPace: Double = 0    // 분/km, 1km 랩 기준 표시
     @Published private(set) var completedLapPaces: [RunLapPace] = []
+    @Published private(set) var elevationGainMeters: Double?
+    @Published private(set) var averageHeartRate: Double?
 
     let locationManager: LocationManager
 
@@ -62,10 +64,17 @@ final class RunningViewModel: ObservableObject {
     private var lapStartElapsedSeconds: Int = 0
     private var lastCompletedLapPace: Double = 0
     private var runningStartedAt: Date?
+    private var healthRunStartedAt: Date?
     private var accumulatedElapsedSecondsBeforeResume: Int = 0
+    private let heartRateRepository: HeartRateRepository
+    private var healthAuthorizationTask: Task<Bool, Never>?
 
-    init(locationManager: LocationManager = .shared) {
+    init(
+        locationManager: LocationManager = .shared,
+        heartRateRepository: HeartRateRepository = HealthKitHeartRateRepository()
+    ) {
         self.locationManager = locationManager
+        self.heartRateRepository = heartRateRepository
         locationManager.startMonitoringCurrentLocation()
 
         locationManager.$recentRecordedLocations
@@ -90,7 +99,12 @@ final class RunningViewModel: ObservableObject {
         lastLocation = nil
         resetLapState()
         accumulatedElapsedSecondsBeforeResume = 0
-        runningStartedAt = Date()
+        let startedAt = Date()
+        runningStartedAt = startedAt
+        healthRunStartedAt = startedAt
+        elevationGainMeters = nil
+        averageHeartRate = nil
+        healthAuthorizationTask = Task { await heartRateRepository.requestReadAuthorization() }
         locationManager.startTracking()
         state = .running
         startTimer()
@@ -115,14 +129,27 @@ final class RunningViewModel: ObservableObject {
         startTimer()
     }
 
-    func stop() {
+    func stop() async {
         syncElapsedSeconds()
         completePendingLapsIfNeeded()
+        let endedAt = Date()
+        let healthStartedAt = healthRunStartedAt
         accumulatedElapsedSecondsBeforeResume = elapsedSeconds
         runningStartedAt = nil
         timer?.cancel()
         locationManager.stopTracking()
         state = .finished
+
+        elevationGainMeters = RunMetricsCalculator.elevationGain(
+            from: locationManager.recordedLocations
+        )
+        if let healthStartedAt {
+            _ = await healthAuthorizationTask?.value
+            averageHeartRate = await heartRateRepository.averageHeartRate(
+                from: healthStartedAt,
+                to: endedAt
+            )
+        }
     }
 
     func reset() {
@@ -135,6 +162,10 @@ final class RunningViewModel: ObservableObject {
         resetLapState()
         accumulatedElapsedSecondsBeforeResume = 0
         runningStartedAt = nil
+        healthRunStartedAt = nil
+        healthAuthorizationTask = nil
+        elevationGainMeters = nil
+        averageHeartRate = nil
         state = .idle
     }
 
@@ -234,7 +265,9 @@ final class RunningViewModel: ObservableObject {
         elapsedSeconds: Int? = nil,
         avgPace: Double? = nil,
         routeCoordinates: [CLLocationCoordinate2D]? = nil,
-        lapPaces: [RunLapPace]? = nil
+        lapPaces: [RunLapPace]? = nil,
+        elevationGainMeters: Double? = nil,
+        averageHeartRate: Double? = nil
     ) async {
         let savedDistance = distance ?? self.distance
         let savedElapsedSeconds = elapsedSeconds ?? self.elapsedSeconds
@@ -260,7 +293,9 @@ final class RunningViewModel: ObservableObject {
             distance: savedDistance,
             avgPace: savedAveragePace,
             routeCoordinates: savedRouteCoordinates,
-            lapPaces: savedLapPaces
+            lapPaces: savedLapPaces,
+            elevationGainMeters: elevationGainMeters ?? self.elevationGainMeters,
+            averageHeartRate: averageHeartRate ?? self.averageHeartRate
         )
         try? await FirestoreService.shared.saveRunRecord(uid: uid, record: record)
 

--- a/Pacing/Pacing/Features/Running/ViewModel/RunningViewModel.swift
+++ b/Pacing/Pacing/Features/Running/ViewModel/RunningViewModel.swift
@@ -212,6 +212,13 @@ final class RunningViewModel: ObservableObject {
         "\(estimatedCalories)"
     }
 
+    var formattedElevationGain: String {
+        guard let elevationGainMeters, elevationGainMeters.isFinite else {
+            return state == .running || state == .paused ? "0m" : "--"
+        }
+        return "\(Int(elevationGainMeters.rounded()))m"
+    }
+
     // MARK: - Private
 
     private func startTimer() {

--- a/Pacing/Pacing/Info.plist
+++ b/Pacing/Pacing/Info.plist
@@ -16,54 +16,6 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
-	<key>CFBundleVersion</key>
-	<string>$(CURRENT_PROJECT_VERSION)</string>
-	<key>LSRequiresIPhoneOS</key>
-	<true/>
-	<key>NSAccentColorName</key>
-	<string>AccentColor</string>
-	<key>NSAppleMusicUsageDescription</key>
-	<string>주변 러너와 음악을 함께 듣기 위해 Apple Music 접근이 필요합니다.</string>
-	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-	<string>러닝 중 경로를 기록하고 주변 러너를 찾기 위해 위치 정보가 필요합니다. 백그라운드에서도 경로가 정확히 기록됩니다.</string>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>러닝 중 경로를 기록하고 주변 러너를 찾기 위해 위치 정보가 필요합니다.</string>
-	<key>UIBackgroundModes</key>
-	<array>
-		<string>location</string>
-		<string>audio</string>
-	</array>
-	<key>UIApplicationSceneManifest</key>
-	<dict>
-		<key>UIApplicationSupportsMultipleScenes</key>
-		<true/>
-		<key>UISceneConfigurations</key>
-		<dict/>
-	</dict>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
-	<key>UILaunchScreen</key>
-	<dict>
-		<key>UILaunchScreen</key>
-		<dict/>
-	</dict>
-	<key>UISupportedInterfaceOrientations~ipad</key>
-	<array>
-		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
-	</array>
-	<key>UISupportedInterfaceOrientations~iphone</key>
-	<array>
-		<string>UIInterfaceOrientationPortrait</string>
-	</array>
-	<key>LSApplicationQueriesSchemes</key>
-	<array>
-		<string>naversearchapp</string>
-		<string>naversearchapplink</string>
-		<string>navercafe</string>
-	</array>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -96,6 +48,56 @@
 				<string>naverPacing</string>
 			</array>
 		</dict>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>naversearchapp</string>
+		<string>naversearchapplink</string>
+		<string>navercafe</string>
+	</array>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSAccentColorName</key>
+	<string>AccentColor</string>
+	<key>NSAppleMusicUsageDescription</key>
+	<string>주변 러너와 음악을 함께 듣기 위해 Apple Music 접근이 필요합니다.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>러닝 중 경로를 기록하고 주변 러너를 찾기 위해 위치 정보가 필요합니다. 백그라운드에서도 경로가 정확히 기록됩니다.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>러닝 중 경로를 기록하고 주변 러너를 찾기 위해 위치 정보가 필요합니다.</string>
+	<key>NSHealthShareUsageDescription</key>
+	<string>러닝 결과에 Apple Watch로 측정한 심박수를 표시하기 위해 건강 데이터 읽기 권한이 필요합니다.</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+		<key>UISceneConfigurations</key>
+		<dict/>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>location</string>
+		<string>audio</string>
+	</array>
+	<key>UILaunchScreen</key>
+	<dict>
+		<key>UILaunchScreen</key>
+		<dict/>
+	</dict>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~iphone</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
 	</array>
 </dict>
 </plist>

--- a/Pacing/Pacing/Models/RunRecord.swift
+++ b/Pacing/Pacing/Models/RunRecord.swift
@@ -16,6 +16,33 @@ struct RunRecord: Identifiable {
     let avgPace: Double        // 분/km
     let routeCoordinates: [CLLocationCoordinate2D]
     let lapPaces: [RunLapPace]
+    let elevationGainMeters: Double?
+    let averageHeartRate: Double?
+    let averageCadence: Double?
+
+    init(
+        id: String,
+        startedAt: Date,
+        duration: Int,
+        distance: Double,
+        avgPace: Double,
+        routeCoordinates: [CLLocationCoordinate2D],
+        lapPaces: [RunLapPace],
+        elevationGainMeters: Double? = nil,
+        averageHeartRate: Double? = nil,
+        averageCadence: Double? = nil
+    ) {
+        self.id = id
+        self.startedAt = startedAt
+        self.duration = duration
+        self.distance = distance
+        self.avgPace = avgPace
+        self.routeCoordinates = routeCoordinates
+        self.lapPaces = lapPaces
+        self.elevationGainMeters = elevationGainMeters
+        self.averageHeartRate = averageHeartRate
+        self.averageCadence = averageCadence
+    }
 }
 
 extension RunRecord {

--- a/Pacing/Pacing/Pacing.entitlements
+++ b/Pacing/Pacing/Pacing.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.healthkit</key>
+	<true/>
 	<key>com.apple.developer.applesignin</key>
 	<array>
 		<string>Default</string>

--- a/doc/fe/plans/feat-결과화면-고도-심박수-healthkit-plan.md
+++ b/doc/fe/plans/feat-결과화면-고도-심박수-healthkit-plan.md
@@ -1,0 +1,148 @@
+# 결과 화면 고도·심박수 표시 및 HealthKit 연동 계획서
+
+> **상태**: 검토 대기
+> **작성일**: 2026-08-28
+> **기준 브랜치**: `dev`
+> **GitHub 이슈**: [#130](https://github.com/kec08/Pacing/issues/130)
+> **작업 브랜치**: `feat/130-healthkit-heart-rate`
+> **관련 이전 PR**: [#129](https://github.com/kec08/Pacing/pull/129) — 머지 완료
+
+## 1. 목적
+
+현재 러닝 종료 결과 화면에는 거리·시간·평균 페이스·칼로리만 표시되고 고도 상승과 BPM이 표시되지 않는다. 이번 작업에서는 고도와 심박수를 실제 측정 데이터에 연결해 결과 화면과 활동 상세 화면에서 6개 지표를 모두 확인할 수 있도록 한다.
+
+측정할 수 없는 값을 추정하거나 0으로 대체하지 않는다. 유효한 센서 데이터가 없으면 해당 지표를 `--`로 표시한다.
+
+## 2. 조사 결과 및 기술 결정
+
+### 2.1 고도 상승
+
+- 위치 샘플의 `CLLocation.altitude`와 `verticalAccuracy`를 사용한다.
+- `verticalAccuracy <= 0`, 허용 정확도 초과, 유한하지 않은 고도는 계산에서 제외한다.
+- 연속 유효 샘플의 양의 변화만 누적하되 작은 변화는 GPS 고도 노이즈로 간주해 제외한다.
+- 표시값은 마지막 고도와 시작 고도의 차이가 아닌 누적 상승 고도(`elevation gain`)다.
+- 유효 샘플이 부족하면 `--`를 표시한다.
+- 고도 원본 샘플은 러닝 시작부터 종료까지 보존하고, pause 구간에서 새 샘플을 거리 계산에 반영하지 않는다.
+
+### 2.2 Apple Watch 심박수
+
+- HealthKit의 `HKQuantityTypeIdentifier.heartRate` 읽기 권한을 요청한다.
+- 러닝 시작·종료 시간 범위의 `HKQuantitySample`만 조회한다.
+- BPM 단위로 변환하고, 30~240 BPM 범위의 유효 샘플만 평균한다.
+- Apple Watch로 식별 가능한 샘플을 우선 사용한다. Watch 샘플이 식별되지 않는 테스트 환경에서는 HealthKit의 유효 심박수 샘플을 fallback으로 사용한다.
+- 권한 거부, HealthKit 미지원 기기, Apple Watch 미연결, 샘플 없음, 조회 오류는 모두 `nil` 상태로 처리하고 화면에 `--`를 표시한다.
+- 심박수를 페이스·칼로리·나이로 추정하지 않는다.
+- 결과 화면 조회 시점이 아니라 해당 러닝 시간대의 샘플만 사용해 기록과 측정 시점을 일치시킨다.
+
+### 2.3 저장 호환성
+
+- `RunRecord`에 `elevationGainMeters`, `averageHeartRate`, `averageCadence` optional 필드를 추가한다.
+- Firestore 저장 시 값이 있을 때만 필드를 기록한다.
+- 기존 Firestore 기록에 새 필드가 없어도 조회가 실패하지 않도록 `nil` fallback을 사용한다.
+- 이번 범위에서 케이던스의 실제 센서 연동은 포함하지 않으며, 기존 `--` 정책을 유지한다.
+
+## 3. 아키텍처 및 책임
+
+```text
+LocationManager
+  └─ 유효 CLLocation 샘플·고도 보존
+
+HealthKitHeartRateRepository
+  └─ 권한 요청·러닝 시간 범위 심박수 조회
+
+RunMetricsCalculator
+  └─ 누적 상승 고도·표시용 지표 계산
+
+RunningViewModel
+  └─ 종료 시 센서 데이터 취합·RunRecord 생성
+
+RunSummaryView / RunActivityDetailView
+  └─ 6개 지표 표시, nil은 --
+
+FirestoreService
+  └─ 신규 optional 필드 저장·기존 기록 호환 조회
+```
+
+View에는 센서 조회나 계산 로직을 넣지 않고 ViewModel과 Repository를 통해 전달한다.
+
+## 4. 작업 순서
+
+1. 결과 화면·활동 상세·`RunRecord`·Firestore 현재 흐름 재점검
+2. 계획 승인 후 GitHub 이슈 생성
+3. `dev` 최신 기준으로 `feat<이슈번호>` 브랜치 분기
+4. HealthKit capability 및 `NSHealthShareUsageDescription` 설정
+5. `HealthKitHeartRateRepository` 구현 및 권한/샘플 없음 상태 처리
+6. 위치 고도 샘플 보존 및 고도 상승 계산 연결
+7. `RunningViewModel` 종료 흐름에 고도·심박수 취합 연결
+8. `RunRecord`·Firestore 저장/조회 확장
+9. 결과 화면·활동 상세 화면에 6개 지표 표시
+10. 단위 테스트·빌드·시뮬레이터 QA·실기기 Apple Watch QA
+11. 최종 보고서 작성 후 PR 생성
+
+## 5. 화면 요구사항
+
+### 결과 화면
+
+- 기존 거리 대형 표시와 시간·평균 페이스·칼로리 구조를 유지한다.
+- 추가 지표 영역에 고도 상승과 평균 BPM을 포함해 총 6개 지표를 표시한다.
+- 고도 예: `18 m`, 심박수 예: `179 BPM`.
+- 측정 불가 시 `--`를 표시한다.
+- 다크 모드에서는 기존 디자인 시스템 색상을 사용한다.
+
+### 활동 상세 화면
+
+- 결과 화면과 동일한 계산·표시 정책을 사용한다.
+- 기존 기록에 신규 필드가 없으면 고도와 BPM을 `--`로 표시한다.
+- 기존 경로·구간별 페이스·출발/도착 표시는 유지한다.
+
+## 6. 테스트 계획
+
+### 단위 테스트
+
+- 유효 수직 정확도 샘플만 고도 계산에 포함되는지 확인
+- 작은 고도 노이즈가 상승 고도에 포함되지 않는지 확인
+- 유효 샘플 부족 시 `nil`인지 확인
+- 심박수 유효 범위 밖 샘플 제외
+- 심박수 샘플 없음·권한 거부 시 `nil`인지 확인
+- 기존 `RunRecord` 생성 호출이 신규 optional 필드 없이도 컴파일되는지 확인
+
+### 실기기 QA
+
+- iPhone 위치 권한 허용·거부
+- HealthKit 읽기 권한 허용·거부
+- Apple Watch 운동 기록이 있는 경우 시간 범위 평균 BPM 표시
+- Apple Watch 미연결 또는 해당 시간대 심박수 없음 시 `--` 표시
+- 고도 정확도 불량 환경에서 값이 과장되지 않는지 확인
+- pause/resume 후 러닝 종료 결과가 정상 표시되는지 확인
+- 라이트/다크 모드 및 작은 화면에서 6개 지표가 겹치지 않는지 확인
+
+## 7. 완료 기준
+
+- [ ] 결과 화면에서 거리·시간·평균 페이스·칼로리·고도 상승·BPM을 모두 확인할 수 있다.
+- [ ] 고도는 유효한 `verticalAccuracy` 샘플만 사용한다.
+- [ ] 심박수는 HealthKit Apple Watch 샘플을 러닝 시간 범위에서 조회한다.
+- [ ] 센서·권한·샘플이 없을 때 해당 값만 `--`로 표시한다.
+- [ ] 임의 추정값으로 고도·심박수를 채우지 않는다.
+- [ ] `RunRecord`와 Firestore 신규 필드가 기존 기록을 깨뜨리지 않는다.
+- [ ] 활동 상세 화면도 결과 화면과 동일한 지표 정책을 사용한다.
+- [ ] 단위 테스트와 Debug 빌드가 통과한다.
+- [ ] Apple Watch가 연결된 iPhone 실기기에서 심박수 표시를 확인한다.
+
+## 8. 리스크 및 제한사항
+
+- 시뮬레이터에서는 Apple Watch 심박수 측정을 검증할 수 없다.
+- HealthKit 읽기 권한 상태는 앱에서 직접 값이 없다고 단정할 수 없으므로, 실제 조회 결과를 함께 확인한다.
+- Apple Watch의 운동 기록이 아직 HealthKit에 저장되지 않은 러닝 직후에는 해당 결과 화면에서 BPM이 `--`일 수 있다.
+- 고도는 GPS 및 기압 센서 품질에 영향을 받으므로 수직 정확도 검증과 노이즈 제거를 적용해도 물리적 측정 오차를 완전히 제거할 수는 없다.
+- 케이던스 실제 연동과 WeatherKit은 이번 작업에서 제외한다.
+
+## 9. 참고 자료
+
+- [Apple Developer — HKQuantityTypeIdentifier](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier)
+- [Apple Developer — HKQuantitySample](https://developer.apple.com/documentation/healthkit/hkquantitysample)
+- [Apple Developer — HKSample](https://developer.apple.com/documentation/healthkit/hksample)
+- [Apple Developer — Authorizing access to health data](https://developer.apple.com/documentation/healthkit/authorizing-access-to-health-data)
+- [Apple Developer — Executing statistics collection queries](https://developer.apple.com/documentation/healthkit/executing-statistics-collection-queries)
+- [Apple Developer — CLLocation altitude](https://developer.apple.com/documentation/corelocation/cllocation/altitude)
+
+> **검토 요청**: 계획 승인 후 이슈 생성과 `feat<이슈번호>` 브랜치 분기를 진행한다.

--- a/doc/fe/reports/feat #130 결과 화면 고도·HealthKit 심박수 최종 보고서.md
+++ b/doc/fe/reports/feat #130 결과 화면 고도·HealthKit 심박수 최종 보고서.md
@@ -2,7 +2,7 @@
 
 > **완료일**: 2026-08-28
 > **관련 이슈**: [#130](https://github.com/kec08/Pacing/issues/130)
-> **PR**: 생성 예정
+> **PR**: [#131](https://github.com/kec08/Pacing/pull/131)
 > **기준 브랜치**: `dev`
 > **작업 브랜치**: `feat/130-healthkit-heart-rate`
 

--- a/doc/fe/reports/feat #130 결과 화면 고도·HealthKit 심박수 최종 보고서.md
+++ b/doc/fe/reports/feat #130 결과 화면 고도·HealthKit 심박수 최종 보고서.md
@@ -1,0 +1,83 @@
+# feat #130 결과 화면 고도·HealthKit 심박수 최종 개발 보고서
+
+> **완료일**: 2026-08-28
+> **관련 이슈**: [#130](https://github.com/kec08/Pacing/issues/130)
+> **PR**: 생성 예정
+> **기준 브랜치**: `dev`
+> **작업 브랜치**: `feat/130-healthkit-heart-rate`
+
+## 구현 요약
+
+러닝 종료 결과 화면과 활동 상세 화면에서 고도 상승과 평균 BPM을 확인할 수 있도록 데이터 흐름을 확장했습니다. 위치 센서의 유효 고도 샘플을 보존해 누적 상승 고도를 계산하고, HealthKit에서 러닝 시간 범위의 심박수 샘플을 조회해 평균 BPM을 표시합니다.
+
+## 구현된 기능
+
+- [x] 러닝 중 고도 상승값을 `0m`에서 시작
+- [x] 유효 위치 샘플 수신 시 고도 상승값 실시간 갱신
+- [x] 고도 정확도·GPS 노이즈 기준을 적용한 누적 상승 고도 계산
+- [x] 결과 화면에 고도 상승·BPM·케이던스 영역 추가
+- [x] 활동 상세 화면에 동일한 6개 지표 구조 추가
+- [x] HealthKit 읽기 권한 요청
+- [x] Apple Watch 심박수 샘플 우선 조회
+- [x] 러닝 시작·종료 시간 범위의 평균 BPM 계산
+- [x] 심박수 권한·샘플·기기 데이터가 없을 때 `--` 표시
+- [x] `RunRecord` 및 Firestore optional 필드 저장·조회
+- [x] 기존 Firestore 기록과의 호환성 유지
+- [ ] 케이던스 실제 측정·평균 계산 — 다음 브랜치에서 `CMPedometer`로 진행
+- [ ] WeatherKit 날씨 연동 — 별도 후속 범위
+
+## 측정 및 계산 정책
+
+### 고도
+
+- `CLLocation.altitude`를 사용합니다.
+- `verticalAccuracy`가 0 이하이거나 30m를 초과하는 샘플은 제외합니다.
+- 2m 미만의 상승 변화는 GPS 고도 노이즈로 보고 제외합니다.
+- 유효한 양의 고도 변화만 누적합니다.
+- 종료 결과에서 유효 샘플이 부족하면 `--`를 표시합니다.
+
+### 심박수
+
+- HealthKit `heartRate` 샘플을 사용합니다.
+- 러닝 전체 시간 범위의 유효 샘플을 조회합니다.
+- Apple Watch로 식별 가능한 샘플을 우선합니다.
+- 30~240 BPM 범위 밖의 샘플은 제외합니다.
+- 유효 샘플의 평균을 BPM으로 표시합니다.
+- 권한 거부·Apple Watch 미연결·샘플 없음·조회 오류는 `--`로 표시합니다.
+
+## 커밋 단위
+
+- `9db9370` 계획서·HealthKit 권한 설정
+- `8980638` 고도 데이터·RunRecord·Firestore 확장
+- `1ebc0d2` HealthKit 심박수 조회·러닝 종료 취합
+- `71b2f4e` 결과·활동 상세 화면 지표 표시
+- `6c8c76d` 러닝 시작 시 고도 0m 표시
+- `dc96ea5` 러닝 중 고도 상승값 실시간 갱신
+
+## QA 결과
+
+| 항목 | 결과 |
+|------|------|
+| iOS Debug 빌드 | ✅ `BUILD SUCCEEDED` |
+| 테스트 타깃 컴파일 | ✅ `TEST BUILD SUCCEEDED` |
+| 고도 계산 단위 테스트 대상 | ✅ 기존 계산기 테스트 포함 |
+| 시뮬레이터 단위 테스트 실행 | ⚠️ 테스트 러너가 결과 없이 종료되어 성공 확정 불가 |
+| Apple Watch 심박수 실기기 검증 | ⏳ iPhone·Apple Watch 연결 환경 필요 |
+| 다크 모드·실제 HealthKit 권한 흐름 | ⏳ 실기기 QA 필요 |
+
+## 알려진 제한사항 및 후속 작업
+
+- 현재 케이던스는 실제 계산하지 않으며 화면에 `--`를 표시합니다. 다음 브랜치에서 `CMPedometer.currentCadence`와 활동 시간 기반 평균식을 구현합니다.
+- 현재 심박수는 앱이 직접 Apple Watch 운동 세션을 생성하지 않고 HealthKit에 저장된 샘플을 읽습니다.
+- HealthKit 심박수와 고도는 시뮬레이터에서 실제 센서 검증이 불가능합니다.
+- WeatherKit 날씨 카드와 1km 지도 annotation 연결은 후속 범위입니다.
+- Xcode 26의 `UIScreen.main` deprecated 경고는 기존 레이아웃 후속 정리 대상입니다.
+
+## 참고 자료
+
+- [Apple HealthKit quantity types](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier)
+- [Apple HKSample](https://developer.apple.com/documentation/healthkit/hksample)
+- [Apple CMPedometerData.currentCadence](https://developer.apple.com/documentation/coremotion/cmpedometerdata/currentcadence)
+- [Apple CLLocation altitude](https://developer.apple.com/documentation/corelocation/cllocation/altitude)
+
+> **개발자 검토 의견**: 고도와 HealthKit 심박수의 데이터 계층·결과 표시를 구현했습니다. 케이던스는 정확한 `CMPedometer` 연동을 위해 다음 브랜치로 분리합니다.


### PR DESCRIPTION
## 요약
- 결과 화면·활동 상세 화면에 고도 상승과 BPM 표시
- CLLocation 고도 샘플 보존 및 누적 상승 고도 계산
- HealthKit heartRate 읽기 권한과 Apple Watch 샘플 조회
- 러닝 시간 범위 평균 심박수 계산 및 미측정 시 `--` 표시
- RunRecord·Firestore optional 필드 확장과 기존 기록 호환
- 최종 개발 보고서 추가

## 검증
- Debug 빌드: ✅ `BUILD SUCCEEDED`
- 테스트 타깃 컴파일: ✅ `TEST BUILD SUCCEEDED`
- 단위 테스트 실행: ⚠️ 테스트 러너가 결과 없이 종료되어 실기기/CI 재검증 필요

## 범위 제외
케이던스는 실제 `CMPedometer` 연동을 위해 다음 브랜치에서 진행합니다. WeatherKit은 별도 후속 범위입니다.

Refs #130