### PR TITLE
fix: active runner Firebase 전송 및 구독 비용 최적화 (#138, #139)

### DIFF
--- a/Pacing/Pacing/Core/Firebase/RealtimeDBService.swift
+++ b/Pacing/Pacing/Core/Firebase/RealtimeDBService.swift
@@ -1,6 +1,7 @@
 import Foundation
 import FirebaseDatabase
 import CoreLocation
+import UIKit
 
 struct ActiveRunner: Identifiable {
     static let maximumAge: TimeInterval = 120
@@ -17,11 +18,38 @@ struct ActiveRunner: Identifiable {
     }
 }
 
+enum ActiveRunnerBroadcastMode {
+    case foreground
+    case background
+    case running
+
+    var minimumInterval: TimeInterval {
+        switch self {
+        case .foreground: return 15
+        case .background: return 60
+        case .running: return 5
+        }
+    }
+
+    var minimumDistance: CLLocationDistance {
+        switch self {
+        case .foreground: return 30
+        case .background: return 50
+        case .running: return 10
+        }
+    }
+}
+
 final class RealtimeDBService {
     static let shared = RealtimeDBService()
     private let db = Database.database(url: "https://pacing-a8639-default-rtdb.firebaseio.com").reference()
     private var broadcastTimer: Timer?
-    private var observeHandle: DatabaseHandle?
+    private var activeRunnerObserverHandles: [DatabaseHandle] = []
+    private var activeRunnerCleanupTimer: Timer?
+    private var activeRunnerCache: [String: ActiveRunner] = [:]
+    private var lastBroadcastCoordinate: CLLocationCoordinate2D?
+    private var lastBroadcastDate: Date?
+    private var lastBroadcastSong: (title: String, artist: String)?
     private var broadcastErrorHandler: ((Error) -> Void)?
 
     private init() {}
@@ -32,6 +60,7 @@ final class RealtimeDBService {
         nickname: String,
         locationProvider: @escaping () -> CLLocationCoordinate2D?,
         songProvider: @escaping () -> (title: String, artist: String),
+        isRunningProvider: @escaping () -> Bool = { false },
         onError: @escaping (Error) -> Void = { _ in }
     ) {
         guard !uid.isEmpty else { return }
@@ -44,7 +73,8 @@ final class RealtimeDBService {
         broadcastTimer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { [weak self] _ in
             let coord = locationProvider()
             let song = songProvider()
-            self?.upload(uid: uid, nickname: nickname, coord: coord, song: song)
+            let mode = Self.broadcastMode(isRunning: isRunningProvider())
+            self?.upload(uid: uid, nickname: nickname, coord: coord, song: song, mode: mode)
         }
         broadcastTimer?.fire()
     }
@@ -53,21 +83,41 @@ final class RealtimeDBService {
         uid: String,
         nickname: String,
         coord: CLLocationCoordinate2D?,
-        song: (title: String, artist: String)
+        song: (title: String, artist: String),
+        isRunning: Bool = false
     ) {
-        upload(uid: uid, nickname: nickname, coord: coord, song: song)
+        upload(
+            uid: uid,
+            nickname: nickname,
+            coord: coord,
+            song: song,
+            mode: Self.broadcastMode(isRunning: isRunning)
+        )
     }
 
     private func upload(
         uid: String,
         nickname: String,
         coord: CLLocationCoordinate2D?,
-        song: (title: String, artist: String)
+        song: (title: String, artist: String),
+        mode: ActiveRunnerBroadcastMode
     ) {
         guard !uid.isEmpty,
               let coord,
               CLLocationCoordinate2DIsValid(coord)
         else { return }
+
+        let now = Date()
+        let distance = lastBroadcastCoordinate.map {
+            CLLocation(latitude: $0.latitude, longitude: $0.longitude)
+                .distance(from: CLLocation(latitude: coord.latitude, longitude: coord.longitude))
+        } ?? .greatestFiniteMagnitude
+        let elapsed = lastBroadcastDate.map { now.timeIntervalSince($0) } ?? .greatestFiniteMagnitude
+        let songChanged = lastBroadcastSong?.title != song.title || lastBroadcastSong?.artist != song.artist
+
+        guard lastBroadcastDate == nil || elapsed >= mode.minimumInterval ||
+                distance >= mode.minimumDistance || songChanged else { return }
+
         var data: [String: Any] = [
             "nickname": nickname,
             "currentSongTitle": song.title,
@@ -77,7 +127,14 @@ final class RealtimeDBService {
         data["latitude"] = coord.latitude
         data["longitude"] = coord.longitude
         db.child("activeRunners").child(uid).updateChildValues(data) { [weak self] error, _ in
-            if let error { self?.broadcastErrorHandler?(error) }
+            guard let self else { return }
+            if let error {
+                self.broadcastErrorHandler?(error)
+            } else {
+                self.lastBroadcastCoordinate = coord
+                self.lastBroadcastDate = now
+                self.lastBroadcastSong = song
+            }
         }
     }
 
@@ -85,6 +142,9 @@ final class RealtimeDBService {
     func stopBroadcast(uid: String) {
         broadcastTimer?.invalidate()
         broadcastTimer = nil
+        lastBroadcastCoordinate = nil
+        lastBroadcastDate = nil
+        lastBroadcastSong = nil
         guard !uid.isEmpty else { return }
         db.child("activeRunners").child(uid).removeValue()
     }
@@ -94,36 +154,64 @@ final class RealtimeDBService {
         onChange: @escaping ([ActiveRunner]) -> Void,
         onError: @escaping (Error) -> Void = { _ in }
     ) {
-        observeHandle = db.child("activeRunners").observe(.value, with: { snapshot in
-            var runners: [ActiveRunner] = []
-            runners.reserveCapacity(Int(snapshot.childrenCount))
-            for child in snapshot.children {
-                guard
-                    let snap = child as? DataSnapshot,
-                    let d = snap.value as? [String: Any]
-                else { continue }
+        stopObserving()
+        activeRunnerCache.removeAll(keepingCapacity: true)
 
-                guard
-                    let lat = Self.doubleValue(d["latitude"]),
-                    let lng = Self.doubleValue(d["longitude"]),
-                    let updatedAt = Self.doubleValue(d["updatedAt"]),
-                    CLLocationCoordinate2DIsValid(CLLocationCoordinate2D(latitude: lat, longitude: lng))
-                else { continue }
-
-                let runner = ActiveRunner(
-                    id: snap.key,
-                    nickname: d["nickname"] as? String ?? "러너",
-                    coordinate: CLLocationCoordinate2D(latitude: lat, longitude: lng),
-                    songTitle: d["currentSongTitle"] as? String ?? "",
-                    artist: d["currentArtist"] as? String ?? "",
-                    updatedAt: updatedAt
-                )
-                if runner.isFresh() {
-                    runners.append(runner)
-                }
-            }
-            onChange(runners)
+        let reference = db.child("activeRunners")
+        let addedHandle = reference.observe(.childAdded, with: { [weak self] snapshot in
+            self?.updateActiveRunner(snapshot, onChange: onChange)
         }, withCancel: onError)
+        let changedHandle = reference.observe(.childChanged, with: { [weak self] snapshot in
+            self?.updateActiveRunner(snapshot, onChange: onChange)
+        }, withCancel: onError)
+        let removedHandle = reference.observe(.childRemoved, with: { [weak self] snapshot in
+            self?.activeRunnerCache.removeValue(forKey: snapshot.key)
+            self?.publishActiveRunners(onChange)
+        }, withCancel: onError)
+        activeRunnerObserverHandles = [addedHandle, changedHandle, removedHandle]
+
+        activeRunnerCleanupTimer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { [weak self] _ in
+            self?.removeStaleActiveRunners(onChange: onChange)
+        }
+    }
+
+    private func updateActiveRunner(_ snapshot: DataSnapshot, onChange: @escaping ([ActiveRunner]) -> Void) {
+        guard let runner = Self.activeRunner(from: snapshot) else {
+            activeRunnerCache.removeValue(forKey: snapshot.key)
+            publishActiveRunners(onChange)
+            return
+        }
+        activeRunnerCache[runner.id] = runner
+        publishActiveRunners(onChange)
+    }
+
+    private static func activeRunner(from snapshot: DataSnapshot) -> ActiveRunner? {
+        guard let d = snapshot.value as? [String: Any],
+              let lat = Self.doubleValue(d["latitude"]),
+              let lng = Self.doubleValue(d["longitude"]),
+              let updatedAt = Self.doubleValue(d["updatedAt"]),
+              CLLocationCoordinate2DIsValid(CLLocationCoordinate2D(latitude: lat, longitude: lng))
+        else { return nil }
+
+        return ActiveRunner(
+            id: snapshot.key,
+            nickname: d["nickname"] as? String ?? "러너",
+            coordinate: CLLocationCoordinate2D(latitude: lat, longitude: lng),
+            songTitle: d["currentSongTitle"] as? String ?? "",
+            artist: d["currentArtist"] as? String ?? "",
+            updatedAt: updatedAt
+        )
+    }
+
+    private func publishActiveRunners(_ onChange: @escaping ([ActiveRunner]) -> Void) {
+        onChange(activeRunnerCache.values.filter { $0.isFresh() }.sorted { $0.id < $1.id })
+    }
+
+    private func removeStaleActiveRunners(onChange: @escaping ([ActiveRunner]) -> Void) {
+        let staleIDs = activeRunnerCache.values.filter { !$0.isFresh() }.map(\.id)
+        guard !staleIDs.isEmpty else { return }
+        staleIDs.forEach { activeRunnerCache.removeValue(forKey: $0) }
+        publishActiveRunners(onChange)
     }
 
     private static func doubleValue(_ value: Any?) -> Double? {
@@ -133,10 +221,17 @@ final class RealtimeDBService {
 
     // MARK: - 구독 해제
     func stopObserving() {
-        if let handle = observeHandle {
-            db.child("activeRunners").removeObserver(withHandle: handle)
-            observeHandle = nil
-        }
+        let reference = db.child("activeRunners")
+        activeRunnerObserverHandles.forEach { reference.removeObserver(withHandle: $0) }
+        activeRunnerObserverHandles.removeAll()
+        activeRunnerCleanupTimer?.invalidate()
+        activeRunnerCleanupTimer = nil
+        activeRunnerCache.removeAll()
+    }
+
+    private static func broadcastMode(isRunning: Bool) -> ActiveRunnerBroadcastMode {
+        if isRunning { return .running }
+        return UIApplication.shared.applicationState == .active ? .foreground : .background
     }
 
     /// 요청 버튼을 누른 순간의 상대방 재생 곡을 한 번 읽습니다.
@@ -147,24 +242,8 @@ final class RealtimeDBService {
 
         return try await withCheckedThrowingContinuation { continuation in
             db.child("activeRunners").child(uid).observeSingleEvent(of: .value) { snapshot in
-                guard let d = snapshot.value as? [String: Any],
-                      let lat = Self.doubleValue(d["latitude"]),
-                      let lng = Self.doubleValue(d["longitude"]),
-                      let updatedAt = Self.doubleValue(d["updatedAt"]),
-                      CLLocationCoordinate2DIsValid(CLLocationCoordinate2D(latitude: lat, longitude: lng))
-                else {
-                    continuation.resume(returning: nil)
-                    return
-                }
-
-                continuation.resume(returning: ActiveRunner(
-                    id: snapshot.key,
-                    nickname: d["nickname"] as? String ?? "러너",
-                    coordinate: CLLocationCoordinate2D(latitude: lat, longitude: lng),
-                    songTitle: d["currentSongTitle"] as? String ?? "",
-                    artist: d["currentArtist"] as? String ?? "",
-                    updatedAt: updatedAt
-                ))
+                let runner = Self.activeRunner(from: snapshot)
+                continuation.resume(returning: runner?.isFresh() == true ? runner : nil)
             } withCancel: { error in
                 continuation.resume(throwing: error)
             }

--- a/Pacing/Pacing/Features/Main/MainTabView.swift
+++ b/Pacing/Pacing/Features/Main/MainTabView.swift
@@ -86,6 +86,8 @@ struct MainTabView: View {
             locationManager.currentLocation?.coordinate
         } songProvider: {
             currentPresenceSong()
+        } isRunningProvider: {
+            selection == .running
         } onError: { error in
             DispatchQueue.main.async {
                 guard lastPresenceErrorDate?.addingTimeInterval(30) ?? .distantPast < .now else { return }
@@ -105,7 +107,8 @@ struct MainTabView: View {
             uid: uid,
             nickname: nickname,
             coord: coordinate,
-            song: currentPresenceSong()
+            song: currentPresenceSong(),
+            isRunning: selection == .running
         )
     }
 

--- a/Pacing/Pacing/Features/Running/View/RunningView.swift
+++ b/Pacing/Pacing/Features/Running/View/RunningView.swift
@@ -343,7 +343,8 @@ struct RunningView: View {
                     uid: uid,
                     nickname: nickname,
                     coord: viewModel.locationManager.currentLocation?.coordinate,
-                    song: (musicVM.currentSong?.title ?? "", musicVM.currentSong?.artistName ?? "")
+                    song: (musicVM.currentSong?.title ?? "", musicVM.currentSong?.artistName ?? ""),
+                    isRunning: viewModel.state == .running || viewModel.state == .paused
                 )
             }
             // 호스트면 세션에도 브로드캐스트

--- a/doc/fe/reports/fix-138-139-firebase-presence-cost-final-report.md
+++ b/doc/fe/reports/fix-138-139-firebase-presence-cost-final-report.md
@@ -1,0 +1,57 @@
+# activeRunners Firebase 위치 공유 비용 최적화 최종 개발 보고서
+
+> **관련 이슈**: [#138](https://github.com/kec08/Pacing/issues/138), [#139](https://github.com/kec08/Pacing/issues/139)  
+> **작성일**: 2026-09-10  
+> **브랜치**: `fix/138-139-firebase-presence-cost`  
+> **상태**: `dev` 대상 PR 생성
+
+## 1. 구현 요약
+
+`activeRunners` 위치 공유에서 발생하던 불필요한 Firebase Realtime Database 읽기·쓰기 요청을 줄였다. 위치 전송 정책을 상태별로 분리하고, 전체 snapshot observer를 child 이벤트 observer로 변경해 기본 위치 공유 기능은 유지하면서 Firebase 과금 및 네트워크 사용량을 낮췄다.
+
+## 2. 변경 사항
+
+- 포그라운드, 백그라운드, 러닝 상태별 위치 전송 정책 적용
+  - 포그라운드: 최소 15초 또는 30m 이동
+  - 백그라운드: 최소 60초 또는 50m 이동
+  - 러닝: 최소 5초 또는 10m 이동
+- 동일 위치·동일 곡에 대한 반복 `activeRunners` write 차단
+- 곡이 변경되면 위치가 같아도 최신 곡 정보를 반영
+- `activeRunners`의 전체 `.value` observer를 `childAdded`, `childChanged`, `childRemoved` observer로 변경
+- observer 재등록 전 기존 observer 및 stale 정리 타이머 해제
+- 30초 주기로 로컬 stale 러너 캐시 정리
+- stale 러너의 단건 조회 결과를 반환하지 않도록 필터링
+- 기존 `onDisconnectRemoveValue`, 브로드캐스트 중지 시 데이터 삭제 동작 유지
+- MainTab 및 Running 화면의 위치·곡 갱신 경로에 러닝 상태 전달
+
+## 3. 과금 방지 효과
+
+- 기존에는 한 명의 위치가 변경될 때마다 `activeRunners` 전체 snapshot을 다시 처리했다.
+- 변경 후에는 변경된 child 데이터만 전달받아 전체 목록 재다운로드를 방지한다.
+- 5초 타이머는 유지하지만 실제 Firebase write 전에 시간·거리·곡 변경 정책을 검사한다.
+- 다른 사용자의 stale 데이터를 클라이언트가 임의 삭제하지 않는다. 현재 Realtime Database 규칙상 타 사용자 데이터 삭제 권한을 추가하지 않고, `onDisconnect`와 로컬 stale 필터로 안전하게 처리했다.
+
+## 4. QA 결과
+
+| 항목 | 결과 | 비고 |
+| --- | --- | --- |
+| `git diff --check` | ✅ 통과 | 변경 파일 기준 |
+| Debug iOS Simulator 빌드 | ✅ 통과 | `xcodebuild -quiet -project Pacing/Pacing.xcodeproj -scheme Pacing -sdk iphonesimulator -configuration Debug -derivedDataPath /private/tmp/pacing-derived-data CODE_SIGNING_ALLOWED=NO build` |
+| 기존 위치 공유 API 호환성 | ✅ 코드 검증 | 기존 메서드 시그니처 기본 동작 유지 |
+| 위치 주기·이동 거리 제한 | ✅ 코드 검증 | 상태별 정책 적용 확인 |
+| child observer 등록·해제 | ✅ 코드 검증 | 중복 등록 및 화면 이탈 해제 확인 |
+| stale 러너 필터링 | ✅ 코드 검증 | 캐시·단건 조회 모두 적용 |
+| 자동 테스트 | ⏳ 실행 보류 | CoreSimulatorService 장애 및 구체적인 Simulator 대상 확인 실패 |
+| 실기기 Firebase 과금·네트워크 확인 | ⏳ 추가 확인 필요 | 개발자 실기기 QA 필요 |
+
+## 5. 알려진 제한사항 및 후속 작업
+
+- 서버에 이미 남아 있는 타 사용자의 stale 데이터를 클라이언트가 직접 삭제하지 않는다. 운영 정리까지 필요하면 Cloud Functions 기반 TTL 정리 작업을 별도 검토해야 한다.
+- Firebase 콘솔의 실제 다운로드량·쓰기량은 실기기 2대 이상으로 위치 이동 및 러닝 상태를 재현해 최종 확인해야 한다.
+- 기존 코드에서 발생하는 iOS 26 `UIScreen.main` deprecation warning은 이번 변경 범위에 포함하지 않았다.
+
+## 6. 주요 커밋
+
+- `8e6ed54 fix: active runner Firebase 전송 및 구독 비용 최적화 (#138, #139)`
+
+> PR은 자동 병합하지 않으며, 최종 검토와 병합은 개발자가 직접 진행한다.


### PR DESCRIPTION
## 개요
activeRunners 위치 공유의 불필요한 Firebase Realtime Database 읽기·쓰기 요청을 줄이고, stale 러너 및 중복 observer 문제를 개선합니다.

## 변경 사항
- 포그라운드·백그라운드·러닝 상태별 위치 전송 주기와 최소 이동 거리 정책 적용
- 동일 위치·동일 곡 반복 write 차단
- activeRunners 전체 snapshot 구독을 childAdded/childChanged/childRemoved로 변경
- 중복 observer 및 화면 이탈 시 observer 해제
- 로컬 stale 러너 캐시와 stale 단건 조회 필터링
- 최종 개발 보고서 추가

## 기술적 고려 사항
- Firebase 쓰기 전 정책 검사를 적용해 전송량과 write 빈도를 제한했습니다.
- 전체 snapshot 대신 child 단위 이벤트를 사용해 변경되지 않은 러너 데이터의 재다운로드를 방지했습니다.
- 현재 Realtime Database 규칙상 타 사용자 데이터는 클라이언트에서 삭제하지 않고 onDisconnect 및 로컬 stale 필터를 유지했습니다.
- 기존 위치 공유·곡 변경·러닝 화면 갱신 흐름과 API 호환성을 유지했습니다.

## 검증
- [x] Debug iOS Simulator 빌드 통과
- [ ] 관련 자동 테스트 통과 — CoreSimulatorService 장애로 실행 보류
- [ ] 실기기 QA 완료 — 개발자 확인 필요
- [x] 로딩/빈 상태/에러 상태 영향 없음 확인
- [x] 다크모드 및 다양한 화면 크기 영향 없음 확인
- [x] git diff --check 통과

## 남은 이슈
- 서버 stale 데이터의 운영 정리까지 필요하면 Cloud Functions 기반 TTL 작업을 별도 검토해야 합니다.
- 실기기에서 위치 이동, 백그라운드 러닝, Firebase 콘솔 다운로드·쓰기량을 최종 확인해야 합니다.

## 관련 이슈
Closes #138
Closes #139

최종 병합은 개발자 검토 후 직접 진행합니다.