### PR TITLE
fix: 1.2.2 App Store 심사 오류 보완 (#151)

### DIFF
--- a/Pacing/Pacing.xcodeproj/project.pbxproj
+++ b/Pacing/Pacing.xcodeproj/project.pbxproj
@@ -468,7 +468,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eunchan.Pacing;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -510,7 +510,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eunchan.Pacing;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -658,7 +658,7 @@
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 12.15.0;
+				minimumVersion = 12.17.0;
 			};
 		};
 		BC57936A2FF2415D006C925A /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */ = {

--- a/Pacing/Pacing/Info.plist
+++ b/Pacing/Pacing/Info.plist
@@ -63,12 +63,14 @@
 	<string>AccentColor</string>
 	<key>NSAppleMusicUsageDescription</key>
 	<string>주변 러너와 음악을 함께 듣기 위해 Apple Music 접근이 필요합니다.</string>
+	<key>NSHealthShareUsageDescription</key>
+	<string>러닝 결과에 Apple Watch로 측정한 심박수를 표시하기 위해 건강 데이터 읽기 권한이 필요합니다.</string>
+	<key>NSHealthUpdateUsageDescription</key>
+	<string>러닝 기록을 건강 데이터와 연동하고 운동 정보를 관리하기 위해 건강 데이터 기록 권한이 필요합니다.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
 	<string>러닝 중 경로를 기록하고 주변 러너를 찾기 위해 위치 정보가 필요합니다. 백그라운드에서도 경로가 정확히 기록됩니다.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>러닝 중 경로를 기록하고 주변 러너를 찾기 위해 위치 정보가 필요합니다.</string>
-	<key>NSHealthShareUsageDescription</key>
-	<string>러닝 결과에 Apple Watch로 측정한 심박수를 표시하기 위해 건강 데이터 읽기 권한이 필요합니다.</string>
 	<key>NSMotionUsageDescription</key>
 	<string>러닝 중 걸음 수를 측정해 정확한 케이던스를 계산하기 위해 동작 및 피트니스 데이터 접근이 필요합니다.</string>
 	<key>UIApplicationSceneManifest</key>

--- a/Pacing/PacingTests/PacingTests.swift
+++ b/Pacing/PacingTests/PacingTests.swift
@@ -63,11 +63,11 @@ final class PacingTests: XCTestCase {
         let referenceDate = Date(timeIntervalSince1970: 1_000)
         let freshRunner = ActiveRunner(
             id: "fresh", nickname: "러너", coordinate: CLLocationCoordinate2D(latitude: 37, longitude: 127),
-            songTitle: "", artist: "", profileImageBase64: nil, updatedAt: 881_000
+            songTitle: "", artist: "", updatedAt: 881_000
         )
         let staleRunner = ActiveRunner(
             id: "stale", nickname: "러너", coordinate: CLLocationCoordinate2D(latitude: 37, longitude: 127),
-            songTitle: "", artist: "", profileImageBase64: nil, updatedAt: 879_000
+            songTitle: "", artist: "", updatedAt: 879_000
         )
 
         XCTAssertTrue(freshRunner.isFresh(referenceDate: referenceDate))

--- a/doc/fe/plans/fix-1.2.2-app-store-submission-plan.md
+++ b/doc/fe/plans/fix-1.2.2-app-store-submission-plan.md
@@ -1,0 +1,77 @@
+# 1.2.2 App Store 심사 대응 계획서
+
+## 목적
+
+App Store Connect에서 1.2.2 빌드가 거절된 원인을 제거하고, `dev` 브랜치에 안전하게 반영할 수 있는 심사 제출용 빌드를 준비한다.
+
+## 심사 오류 범위
+
+- 지원되지 않는 SDK 또는 Xcode 버전으로 빌드됨
+- `NSHealthUpdateUsageDescription` 목적 문자열 누락
+- FirebaseFirestoreInternal, absl, grpc, grpcpp, openssl_grpc framework의 dSYM 업로드 실패
+
+## 사용자·배포 시나리오
+
+- 사용자는 1.2.2 앱을 설치하고 기존 러닝·HealthKit 심박수 기능을 사용할 수 있다.
+- HealthKit 권한 요청 화면에는 심박수 데이터를 읽고 필요한 경우 기록하는 목적이 명확하게 표시된다.
+- App Store Connect에는 앱 바이너리와 Firebase 포함 framework의 대응 dSYM이 함께 업로드된다.
+- 앱 동작 변경 없이 심사 메타데이터와 배포 빌드 설정만 보완한다.
+
+## 구현 계획
+
+### Task 1. 기준 브랜치 및 빌드 환경 확인
+
+- `origin/dev`의 최신 커밋과 현재 작업 트리 변경을 확인한다.
+- 설치된 Xcode와 SDK 버전을 확인하고 프로젝트의 `LastUpgradeCheck`, deployment target, build settings를 점검한다.
+- 심사 제출에 사용할 Release archive의 SDK/Xcode가 Apple 지원 범위인지 개발자 확인 항목으로 분리한다.
+
+### Task 2. HealthKit 목적 문자열 보완
+
+- 앱의 HealthKit 사용 방식에 맞는 `NSHealthUpdateUsageDescription`을 `Info.plist`에 추가한다.
+- 기존 `NSHealthShareUsageDescription`과 문구가 충돌하지 않도록 읽기·기록 목적을 구분한다.
+- HealthKit capability와 entitlements가 실제 사용 코드와 일치하는지 확인한다.
+
+### Task 3. Firebase dSYM 생성·업로드 경로 보완
+
+- Swift Package Manager로 연결된 Firebase SDK 및 transitive binary framework의 버전을 확인한다.
+- Release archive에서 각 framework의 UUID와 dSYM 대응 여부를 검사한다.
+- `DWARF with dSYM File`, strip/embedding 설정 및 symbol upload 단계에서 dSYM이 누락되지 않도록 필요한 최소 설정을 적용한다.
+- SDK 자체에서 dSYM을 제공하지 않는 경우에는 Firebase SDK 업데이트 또는 배포 환경에서 제공되는 공식 symbols 처리 방법을 우선 검토한다.
+
+### Task 4. 버전 및 심사 빌드 검증
+
+- 앱 target의 marketing version이 `1.2.2`인지 확인하고 build number 정책을 점검한다.
+- Debug Simulator 빌드 및 가능한 범위의 Release archive를 실행한다.
+- archive의 `Info.plist`, entitlements, embedded frameworks, dSYM UUID를 정적 검사한다.
+- `git diff --check`와 관련 자동 테스트를 실행한다.
+
+### Task 5. 문서화 및 PR
+
+- QA 결과와 실기기/App Store Connect 재업로드 필요 항목을 최종 보고서에 기록한다.
+- Conventional Commit 형식으로 의미 단위 커밋을 생성하고 원격 브랜치에 push한다.
+- `dev`를 base로 하는 PR을 생성한다. PR에는 SDK/Xcode 확인 결과와 dSYM 검증 결과를 명시한다.
+- PR 생성 후 머지는 개발자가 직접 진행한다.
+
+## 영향 범위 및 비범위
+
+- 영향 범위: `Info.plist`, Xcode 프로젝트 빌드 설정, Firebase 패키지/archive symbol 처리, 배포 문서.
+- 비범위: 러닝·음악·같이 듣기 기능의 동작 변경, Firebase 데이터 구조 변경, App Store Connect에서의 실제 제출·심사 요청.
+- Xcode/SDK 지원 버전 자체는 프로젝트 코드만으로 보장할 수 없으므로, 최종 archive는 개발자 Mac의 최신 Release Candidate 환경에서 생성한다.
+
+## 완료 기준
+
+- [x] `NSHealthUpdateUsageDescription`이 앱의 `Info.plist`에 추가된다.
+- [x] `NSHealthShareUsageDescription`과 HealthKit capability 설정을 코드 기준으로 확인한다.
+- [x] 프로젝트의 1.2.2 버전과 build number가 확인된다.
+- [ ] 사용 중인 Xcode/SDK가 App Store 제출 지원 범위인지 확인된다.
+- [ ] Firebase 관련 framework의 dSYM UUID 대응을 최종 archive에서 확인한다.
+- [x] `git diff --check`와 Debug Simulator 테스트가 통과한다.
+- [x] QA 결과와 잔여 실기기/App Store Connect 검증 항목이 문서화된다.
+- [ ] `dev` 대상 PR이 생성된다.
+
+## 예상 소요
+
+- 환경·의존성 점검: 30분
+- Info.plist 및 빌드 설정 보완: 30분~1시간
+- archive/dSYM 검증: 1~2시간
+- QA·문서화·PR: 30분~1시간

--- a/doc/reports/fix-1.2.2-app-store-submission-final-report.md
+++ b/doc/reports/fix-1.2.2-app-store-submission-final-report.md
@@ -1,0 +1,45 @@
+# 1.2.2 App Store 심사 대응 최종 보고서
+
+## 구현 요약
+
+App Store Connect 심사 오류 중 앱 번들에서 수정 가능한 HealthKit 목적 문자열을 보완하고, Firebase Swift Package Manager 의존성을 공식 지원 환경에 맞춰 갱신했다. 기존 기능 동작은 변경하지 않았다.
+
+## 변경 사항
+
+| 항목 | 변경 내용 |
+| --- | --- |
+| HealthKit | `NSHealthUpdateUsageDescription` 추가 |
+| Firebase | 최소 버전 `12.15.0` → `12.17.0`으로 상향. 실제 resolve 버전은 `12.18.0` |
+| 앱 버전 | Debug/Release marketing version `1.2.2` 확인 |
+| 심볼 | Release `DEBUG_INFORMATION_FORMAT = dwarf-with-dsym` 기존 설정 확인 |
+| 테스트 호환성 | 현재 `ActiveRunner` initializer와 맞지 않던 테스트 인자 제거 |
+
+## 검증 결과
+
+- [x] `plutil -lint Pacing/Pacing/Info.plist`
+- [x] Release build settings에서 `MARKETING_VERSION = 1.2.2` 확인
+- [x] Release build settings에서 `CURRENT_PROJECT_VERSION = 1` 확인
+- [x] Release build settings에서 `DEBUG_INFORMATION_FORMAT = dwarf-with-dsym` 확인
+- [x] 깨끗한 임시 경로에서 SwiftPM 의존성 resolve 성공
+- [x] Debug iOS Simulator 자동 테스트 통과
+- [x] `git diff --check` 통과
+- [ ] Release archive 및 Firebase framework dSYM UUID 대응 확인
+- [ ] 최신 Release Candidate Xcode/SDK에서 실제 App Store Connect 업로드 확인
+- [ ] Apple Developer 계정이 연결된 실기기 QA 완료
+
+## 남은 이슈 및 제출 전 필수 작업
+
+1. 현재 Mac은 `Xcode 26.0 (17A324)`이므로 제출 archive 생성에 사용하지 않는다. Apple 공식 릴리스 페이지 기준 최신 Release Candidate 환경에서 archive한다.
+2. Firebase Firestore SPM 기본 precompiled binary와 absl/gRPC binary는 로컬 임시 checkout에서 자체 dSYM을 포함하지 않는 것으로 확인됐다. Firebase 12.18.0으로 갱신했지만, 최종 archive에서 심사 오류 UUID가 사라졌는지 반드시 확인한다.
+3. 최종 archive에서 `Pacing.app/Info.plist`의 `NSHealthUpdateUsageDescription`, 앱 버전·build number, entitlements를 확인한 뒤 업로드한다.
+
+## 관련 파일
+
+- `doc/fe/plans/fix-1.2.2-app-store-submission-plan.md`
+- `Pacing/Pacing/Info.plist`
+- `Pacing/Pacing.xcodeproj/project.pbxproj`
+- `Pacing/PacingTests/PacingTests.swift`
+
+## 관련 이슈
+
+Closes #151


### PR DESCRIPTION
## 개요
App Store Connect 1.2.2 심사에서 발생한 HealthKit purpose string 누락과 Firebase SDK 기준 문제를 보완하고, 재현 가능한 검증 결과를 문서화합니다.

## 변경 사항
- `NSHealthUpdateUsageDescription` 추가
- Firebase iOS SDK 최소 버전을 12.15.0에서 12.17.0으로 상향
- 현재 모델과 불일치하던 `ActiveRunner` 테스트 인자 제거
- 심사 대응 계획서 및 최종 검증 보고서 추가

## 기술적 고려 사항
- View/MVVM 및 앱 기능 로직은 변경하지 않았습니다.
- HealthKit capability와 기존 심박수 읽기 목적 문구를 유지하면서 기록 목적 문구를 추가했습니다.
- Release 설정의 `DEBUG_INFORMATION_FORMAT = dwarf-with-dsym`은 기존 값을 확인했습니다.
- SwiftPM resolve 결과 Firebase 12.18.0을 확인했습니다.

## 검증
- [x] `plutil -lint Pacing/Pacing/Info.plist`
- [x] Debug iOS Simulator 자동 테스트 통과
- [x] Release version/build 설정 확인 (`1.2.2` / `1`)
- [x] `git diff --check` 통과
- [x] 깨끗한 임시 경로에서 SwiftPM 의존성 resolve 성공
- [ ] 최신 Release Candidate Xcode/SDK에서 Release archive 재생성
- [ ] 최종 archive의 Firebase framework dSYM UUID 대응 확인
- [ ] 실기기 QA 완료

## 남은 이슈
- 현재 로컬은 Xcode 26.0 (17A324)입니다. Apple 공식 릴리스 페이지 기준 최신 RC 환경에서 최종 archive를 생성해야 합니다.
- Firebase Firestore SPM precompiled binary의 FirebaseFirestoreInternal/absl/gRPC dSYM 포함 여부는 최신 RC archive에서 재확인해야 합니다.
- 본 PR은 코드를 머지하지 않으며 최종 검토·머지는 개발자가 진행합니다.

## 관련 이슈
Closes #151
